### PR TITLE
ホーム画面UIデザイン改修

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -8,12 +8,10 @@ class App extends StatelessWidget {
   static final _theme = ThemeData(
     useMaterial3: true,
     colorScheme: _colorScheme,
-    scaffoldBackgroundColor: _colorScheme.surfaceContainerHigh,
+    scaffoldBackgroundColor: _colorScheme.surface,
     appBarTheme: AppBarTheme(
-      backgroundColor: _colorScheme.surfaceContainerHigh,
-      surfaceTintColor: Colors.transparent,
+      backgroundColor: _colorScheme.surface,
       elevation: 0,
-      scrolledUnderElevation: 0,
     ),
     cardTheme: CardThemeData(
       color: _colorScheme.surface,

--- a/lib/ui/common/GlassAppBar.dart
+++ b/lib/ui/common/GlassAppBar.dart
@@ -1,0 +1,36 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+//ref: https://qiita.com/e_kei/items/117c81f15217e3015c49
+class GlassAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final Widget title;
+  final double blur;
+  final double opacity;
+
+  const GlassAppBar({
+    super.key,
+    required this.title,
+    this.blur = 25.0,
+    this.opacity = 0.70,
+  });
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    final backgroundColor = Theme.of(context).colorScheme.surface.withValues(alpha: opacity);
+    return ClipRect(
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: blur, sigmaY: blur),
+        child: AppBar(
+          title: title,
+          backgroundColor: backgroundColor,
+          elevation: 0,
+          scrolledUnderElevation: 0,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/home/viewmodel/home_view_model.dart
+++ b/lib/ui/home/viewmodel/home_view_model.dart
@@ -130,6 +130,112 @@ class HomeViewModel extends _$HomeViewModel {
       scheduleUnit: ScheduleUnit.week,
       executedAt: now.subtract(const Duration(days: 4)),
     );
+
+    // 超過: 1ヶ月スケジュール, 10日超過
+    await _repository.addScheduledTask(
+      icon: '🚗',
+      name: '洗車',
+      color: TaskColor.blue,
+      scheduleValue: 1,
+      scheduleUnit: ScheduleUnit.month,
+      executedAt: now.subtract(const Duration(days: 40)),
+    );
+
+    // ~90%: 1週間スケジュール, 6/7日
+    await _repository.addScheduledTask(
+      icon: '🪴',
+      name: '観葉植物の水やり',
+      color: TaskColor.green,
+      scheduleValue: 1,
+      scheduleUnit: ScheduleUnit.week,
+      executedAt: now.subtract(const Duration(days: 6)),
+    );
+
+    // ~70%: 12ヶ月スケジュール, 255/365日
+    await _repository.addScheduledTask(
+      icon: '🔥',
+      name: '火災報知器の電池交換',
+      color: TaskColor.red,
+      scheduleValue: 12,
+      scheduleUnit: ScheduleUnit.month,
+      executedAt: now.subtract(const Duration(days: 255)),
+    );
+
+    // ~60%: avg 60日サイクル, 36/60日
+    final bathId = await _repository.addPeriodTask(
+      icon: '🛁',
+      name: 'バスルーム大掃除',
+      color: TaskColor.orange,
+      executedAt: now.subtract(const Duration(days: 36)),
+    );
+    await _repository.recordExecution(
+      bathId,
+      executedAt: now.subtract(const Duration(days: 96)),
+    );
+
+    // ~50%: 2ヶ月スケジュール, 30/60日
+    await _repository.addScheduledTask(
+      icon: '💊',
+      name: 'サプリ補充',
+      color: TaskColor.yellow,
+      scheduleValue: 2,
+      scheduleUnit: ScheduleUnit.month,
+      executedAt: now.subtract(const Duration(days: 30)),
+    );
+
+    // ~20%: 12ヶ月スケジュール, 73/365日
+    await _repository.addScheduledTask(
+      icon: '🧯',
+      name: '消火器の点検',
+      color: TaskColor.red,
+      scheduleValue: 12,
+      scheduleUnit: ScheduleUnit.month,
+      executedAt: now.subtract(const Duration(days: 73)),
+    );
+
+    // ~10%: avg 200日サイクル, 20/200日
+    final pcId = await _repository.addPeriodTask(
+      icon: '🖥️',
+      name: 'PCのホコリ掃除',
+      color: TaskColor.none,
+      executedAt: now.subtract(const Duration(days: 20)),
+    );
+    await _repository.recordExecution(
+      pcId,
+      executedAt: now.subtract(const Duration(days: 220)),
+    );
+
+    // 超過: avg 14日サイクル, 2日超過
+    final plantId = await _repository.addPeriodTask(
+      icon: '🌿',
+      name: 'ベランダの草むしり',
+      color: TaskColor.green,
+      executedAt: now.subtract(const Duration(days: 16)),
+    );
+    await _repository.recordExecution(
+      plantId,
+      executedAt: now.subtract(const Duration(days: 30)),
+    );
+
+    // ~35%: 3ヶ月スケジュール, 32/90日
+    await _repository.addScheduledTask(
+      icon: '👟',
+      name: 'スニーカーの洗濯',
+      color: TaskColor.blue,
+      scheduleValue: 3,
+      scheduleUnit: ScheduleUnit.month,
+      executedAt: now.subtract(const Duration(days: 32)),
+    );
+
+    // ~75%: 1ヶ月スケジュール, 22/30日
+    await _repository.addScheduledTask(
+      icon: '🧹',
+      name: '排水口の掃除',
+      color: TaskColor.orange,
+      scheduleValue: 1,
+      scheduleUnit: ScheduleUnit.month,
+      executedAt: now.subtract(const Duration(days: 22)),
+    );
   }
 
   void updateSearchQuery(String query) {

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -32,6 +32,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     }
 
     return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {},
+        child: const Icon(Icons.add),
+      ),
       extendBodyBehindAppBar: true,
       appBar: GlassAppBar(
         title: _SearchBarField(
@@ -147,7 +151,10 @@ class _TaskListView extends StatelessWidget {
     final topPadding = MediaQuery.paddingOf(context).top;
     final bottomPadding = MediaQuery.paddingOf(context).bottom;
     return ListView.builder(
-      padding: EdgeInsets.only(top: 8 + topPadding, bottom: 8 + bottomPadding),
+      padding: EdgeInsets.only(
+        top: 8 + topPadding,
+        bottom: 80 + 8 + bottomPadding,
+      ),
       itemCount: tasks.length,
       itemBuilder: (context, index) => TaskListItem(task: tasks[index]),
     );

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -1,9 +1,10 @@
 import 'package:dawnbreaker/data/model/task_item.dart';
-import 'package:dawnbreaker/ui/home/viewmodel/home_ui_state.dart';
 import 'package:dawnbreaker/ui/home/viewmodel/home_view_model.dart';
 import 'package:dawnbreaker/ui/home/widgets/task_list_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../common/GlassAppBar.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -25,34 +26,34 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   Widget build(BuildContext context) {
     final uiState = ref.watch(homeViewModelProvider);
     final viewModel = ref.read(homeViewModelProvider.notifier);
+
+    if (uiState.isLoading) {
+      return const Scaffold(body: _LoadingView());
+    }
+
     return Scaffold(
-      appBar: AppBar(title: const Text('タスク')),
+      extendBodyBehindAppBar: true,
+      appBar: GlassAppBar(
+        title: _SearchBarField(
+          controller: _searchController,
+          showClear: uiState.searchQuery.isNotEmpty,
+          onChanged: viewModel.updateSearchQuery,
+          onClear: () {
+            _searchController.clear();
+            viewModel.updateSearchQuery('');
+          },
+        ),
+        opacity: 0.20,
+      ),
       body: GestureDetector(
         onTap: () => FocusScope.of(context).unfocus(),
         behavior: HitTestBehavior.translucent,
-        child: Column(
-          children: [
-            if (uiState.hasTasks)
-              _SearchBar(
-                controller: _searchController,
-                showClear: uiState.searchQuery.isNotEmpty,
-                onChanged: viewModel.updateSearchQuery,
-                onClear: () {
-                  _searchController.clear();
-                  viewModel.updateSearchQuery('');
-                },
-              ),
-            Expanded(child: _bodyWidget(uiState)),
-          ],
-        ),
+        child: _bodyWidget(context, uiState),
       ),
     );
   }
 
-  Widget _bodyWidget(HomeUiState uiState) {
-    if (uiState.isLoading) {
-      return const _LoadingView();
-    }
+  Widget _bodyWidget(BuildContext context, dynamic uiState) {
     if (!uiState.hasTasks) {
       return const _EmptyView(message: 'タスクがまだありません');
     }
@@ -89,8 +90,8 @@ class _EmptyView extends StatelessWidget {
   }
 }
 
-class _SearchBar extends StatelessWidget {
-  const _SearchBar({
+class _SearchBarField extends StatelessWidget {
+  const _SearchBarField({
     required this.controller,
     required this.showClear,
     required this.onChanged,
@@ -111,7 +112,7 @@ class _SearchBar extends StatelessWidget {
       borderSide: BorderSide.none,
     );
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: TextField(
         controller: controller,
         onChanged: onChanged,
@@ -143,9 +144,10 @@ class _TaskListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final topPadding = MediaQuery.paddingOf(context).top;
     final bottomPadding = MediaQuery.paddingOf(context).bottom;
     return ListView.builder(
-      padding: EdgeInsets.only(top: 8, bottom: 8 + bottomPadding),
+      padding: EdgeInsets.only(top: 8 + topPadding, bottom: 8 + bottomPadding),
       itemCount: tasks.length,
       itemBuilder: (context, index) => TaskListItem(task: tasks[index]),
     );

--- a/lib/ui/home/widgets/task_list_item.dart
+++ b/lib/ui/home/widgets/task_list_item.dart
@@ -16,27 +16,46 @@ class TaskListItem extends StatelessWidget {
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      color: colorScheme.surface,
+      clipBehavior: Clip.antiAlias,
       shape: RoundedRectangleBorder(
         borderRadius: cardRadius,
-        side: BorderSide(
-          color: colorScheme.outlineVariant.withValues(alpha: 0.5),
-        ),
+        side: BorderSide(color: colorScheme.outlineVariant),
       ),
       child: InkWell(
         onTap: () {},
         borderRadius: cardRadius,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 14, 12, 14),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+        child: IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              _buildTitleRow(theme, colorScheme),
-              const SizedBox(height: 8),
-              _buildDateRow(context, theme, colorScheme, taskProgress),
-              if (taskProgress case DueDate()) ...[
-                const SizedBox(height: 10),
-                _buildProgressRow(theme, colorScheme, taskProgress),
-              ],
+              Container(width: 6, color: task.color.color),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      _EmojiCircle(icon: task.icon, colorScheme: colorScheme),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            _buildTitleRow(theme, colorScheme),
+                            if (taskProgress is DueDate) ...[
+                              const SizedBox(height: 4),
+                              _buildDateInfo(theme, colorScheme, taskProgress),
+                              const SizedBox(height: 8),
+                              _buildProgressBar(colorScheme, taskProgress),
+                            ],
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
             ],
           ),
         ),
@@ -47,22 +66,9 @@ class TaskListItem extends StatelessWidget {
   Widget _buildTitleRow(ThemeData theme, ColorScheme colorScheme) {
     return Row(
       children: [
-        Container(
-          width: 10,
-          height: 10,
-          decoration: BoxDecoration(
-            color: task.color.color,
-            shape: BoxShape.circle,
-          ),
-        ),
-        const SizedBox(width: 8),
         Expanded(child: Text(task.name, style: theme.textTheme.titleMedium)),
         const SizedBox(width: 4),
-        Icon(
-          Icons.replay_rounded,
-          size: 18,
-          color: colorScheme.onSurfaceVariant,
-        ),
+        Icon(Icons.replay_rounded, size: 18, color: colorScheme.onSurfaceVariant),
         const SizedBox(width: 2),
         Text(
           '再登録',
@@ -74,98 +80,68 @@ class TaskListItem extends StatelessWidget {
     );
   }
 
-  Widget _buildDateRow(
-    BuildContext context,
-    ThemeData theme,
-    ColorScheme colorScheme,
-    TaskProgress taskProgress,
-  ) {
-    return Row(
-      children: [
-        Icon(
-          Icons.calendar_today_outlined,
-          size: 13,
-          color: colorScheme.onSurfaceVariant,
-        ),
-        const SizedBox(width: 4),
-        if (task.lastExecutedAt != null)
-          Text(
-            _formatDate(context, task.lastExecutedAt!),
-            style: theme.textTheme.labelMedium?.copyWith(
-              color: colorScheme.onSurfaceVariant,
-            ),
-          ),
-        if (taskProgress case DueDate(:final scheduledAt)) ...[
-          const SizedBox(width: 8),
-          Icon(
-            Icons.arrow_forward,
-            size: 13,
-            color: colorScheme.onSurfaceVariant,
-          ),
-          const SizedBox(width: 8),
-          Icon(
-            Icons.event_outlined,
-            size: 13,
-            color: taskProgress.dueDateColor(colorScheme),
-          ),
-          const SizedBox(width: 4),
-          Text(
-            _formatDate(context, scheduledAt),
-            style: theme.textTheme.labelMedium?.copyWith(
-              color: taskProgress.dueDateColor(colorScheme),
-            ),
-          ),
-        ],
-      ],
-    );
-  }
-
-  Widget _buildProgressRow(
+  Widget _buildDateInfo(
     ThemeData theme,
     ColorScheme colorScheme,
     DueDate taskProgress,
   ) {
-    final progressColor = taskProgress.progressColor(colorScheme);
+    final date = taskProgress.scheduledAt;
+    final dateStr = '${date.year}/${date.month}/${date.day}';
+    final remainStr = taskProgress.isOverdue
+        ? '${taskProgress.daysRemaining.abs()}日超過'
+        : '残り${taskProgress.daysRemaining}日';
+    final color =
+        taskProgress.isOverdue ? colorScheme.error : colorScheme.onSurfaceVariant;
 
     return Row(
       children: [
-        Expanded(
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: LinearProgressIndicator(
-              value: taskProgress.progress,
-              minHeight: 6,
-              backgroundColor: colorScheme.surfaceContainerHighest,
-              valueColor: AlwaysStoppedAnimation<Color>(progressColor),
-            ),
-          ),
-        ),
-        const SizedBox(width: 10),
+        Icon(Icons.event_outlined, size: 13, color: color),
+        const SizedBox(width: 4),
         Text(
-          taskProgress.isOverdue
-              ? '${taskProgress.daysRemaining.abs()}日超過'
-              : '残り${taskProgress.daysRemaining}日',
-          style: theme.textTheme.labelSmall?.copyWith(
-            color: progressColor,
-            fontWeight: FontWeight.w600,
-          ),
+          '$dateStr（$remainStr）',
+          style: theme.textTheme.labelMedium?.copyWith(color: color),
         ),
       ],
     );
   }
 
-  String _formatDate(BuildContext context, DateTime date) {
-    return MaterialLocalizations.of(context).formatShortDate(date);
+  Widget _buildProgressBar(ColorScheme colorScheme, DueDate taskProgress) {
+    final progressColor = taskProgress.isOverdue
+        ? colorScheme.error
+        : taskProgress.progress > 0.5
+        ? colorScheme.tertiary
+        : colorScheme.primary;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(4),
+      child: LinearProgressIndicator(
+        value: taskProgress.progress,
+        minHeight: 6,
+        backgroundColor: colorScheme.surfaceContainerHighest,
+        valueColor: AlwaysStoppedAnimation<Color>(progressColor),
+      ),
+    );
   }
 }
 
-extension _DueDateColors on DueDate {
-  Color progressColor(ColorScheme colorScheme) => isOverdue
-      ? colorScheme.error
-      : progress > 0.5
-      ? colorScheme.tertiary
-      : colorScheme.primary;
+class _EmojiCircle extends StatelessWidget {
+  const _EmojiCircle({required this.icon, required this.colorScheme});
 
-  Color dueDateColor(ColorScheme colorScheme) =>
-      isOverdue ? colorScheme.error : colorScheme.onSurfaceVariant;
+  final String icon;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 44,
+      height: 44,
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
+        shape: BoxShape.circle,
+      ),
+      child: Center(
+        child: Text(icon, style: const TextStyle(fontSize: 22)),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- AppBarを検索バーのみのすりガラス（GlassAppBar）に変更（`BackdropFilter` + `extendBodyBehindAppBar`）
- タスクカードを白背景＋アウトライン枠＋左カラーアクセントバーのデザインに刷新
- タスクアイコンをカード内の絵文字サークルとして表示
- 日付表示を `yyyy/M/d（残りN日 / N日超過）` 形式に簡略化、超過時は赤色表示
- ダミータスクを18件に増量してスクロール確認
- ホーム画面にFAB（タスク追加ボタン、アクションは未実装）を追加

## Screenshot

<img width="350" alt="screenshot_20260417201555" src="https://github.com/user-attachments/assets/1ebd8b8e-5fc3-487d-bb6f-ccd8349621a4" />