### PR TITLE
EditorScreen 実装（タスク追加・編集画面）

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,6 +1,6 @@
+import 'package:dawnbreaker/app/router.dart';
 import 'package:dawnbreaker/core/context_extension.dart';
 import 'package:dawnbreaker/l10n/app_localizations.dart';
-import 'package:dawnbreaker/ui/home/widgets/home_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
@@ -25,7 +25,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       onGenerateTitle: (context) => context.l10n.title,
       theme: _theme,
       localizationsDelegates: const [
@@ -35,7 +35,7 @@ class App extends StatelessWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const HomeScreen(),
+      routerConfig: appRouter,
     );
   }
 }

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,0 +1,16 @@
+import 'package:dawnbreaker/ui/editor/widgets/editor_screen.dart';
+import 'package:dawnbreaker/ui/home/widgets/home_screen.dart';
+import 'package:go_router/go_router.dart';
+
+final appRouter = GoRouter(
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (_, __) => const HomeScreen(),
+    ),
+    GoRoute(
+      path: '/editor',
+      builder: (_, state) => EditorScreen(taskId: state.extra as int?),
+    ),
+  ],
+);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -27,5 +27,36 @@
   "errorUnknown": "An unexpected error occurred",
   "ok": "OK",
   "cancel": "Cancel",
-  "retry": "Retry"
+  "retry": "Retry",
+  "editorTitleNew": "Add Task",
+  "editorTitleEdit": "Edit Task",
+  "editorSectionBasic": "Basic info",
+  "editorLabelName": "Task name",
+  "editorLabelType": "Task type",
+  "editorLabelColor": "Color",
+  "editorLabelSpan": "Interval",
+  "editorLabelIcon": "Icon",
+  "editorChangeIcon": "Change icon",
+  "editorTypeIrregular": "No due date",
+  "editorTypeIrregularDesc": "For irregular tasks — no due date shown",
+  "editorTypePeriod": "Auto-detect interval",
+  "editorTypePeriodDesc": "Next due date inferred from task history",
+  "editorTypeScheduled": "Set interval",
+  "editorTypeScheduledDesc": "Manually set the interval to the next due date",
+  "editorSpanDay": "days",
+  "editorSpanWeek": "weeks",
+  "editorSpanMonth": "months",
+  "editorSpanLabel": "Every {value} {unit}",
+  "@editorSpanLabel": {
+    "placeholders": {
+      "value": { "type": "String" },
+      "unit": { "type": "String" }
+    }
+  },
+  "editorSaveNew": "Add",
+  "editorSaveEdit": "Update",
+  "editorIconDialogTitle": "Select icon",
+  "editorColorNone": "None",
+  "editorColorNote": "Select a color to group your tasks",
+  "editorNameHint": "e.g. Dentist appointment"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -27,5 +27,36 @@
   "errorUnknown": "予期しないエラーが発生しました",
   "ok": "OK",
   "cancel": "キャンセル",
-  "retry": "再試行"
+  "retry": "再試行",
+  "editorTitleNew": "新規タスクを追加",
+  "editorTitleEdit": "タスクを編集",
+  "editorSectionBasic": "基本情報",
+  "editorLabelName": "タスク名",
+  "editorLabelType": "タスク種別",
+  "editorLabelColor": "カラー",
+  "editorLabelSpan": "実行スパン",
+  "editorLabelIcon": "アイコン",
+  "editorChangeIcon": "アイコンを変更する",
+  "editorTypeIrregular": "予定日を表示しない",
+  "editorTypeIrregularDesc": "不定期に実行するタスクで予定日を表示しません",
+  "editorTypePeriod": "自動的に周期を判定",
+  "editorTypePeriodDesc": "タスクの実行履歴から次の予定日を表示します",
+  "editorTypeScheduled": "周期を指定",
+  "editorTypeScheduledDesc": "次の予定日までの間隔を手動で設定します",
+  "editorSpanDay": "日",
+  "editorSpanWeek": "週",
+  "editorSpanMonth": "ヶ月",
+  "editorSpanLabel": "{value}{unit}ごと",
+  "@editorSpanLabel": {
+    "placeholders": {
+      "value": { "type": "String" },
+      "unit": { "type": "String" }
+    }
+  },
+  "editorSaveNew": "登録",
+  "editorSaveEdit": "更新",
+  "editorIconDialogTitle": "アイコンを選択",
+  "editorColorNone": "なし",
+  "editorColorNote": "色を選択することでタスクのグループ分けに使えます",
+  "editorNameHint": "例：歯医者の予約"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -205,6 +205,156 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'再試行'**
   String get retry;
+
+  /// No description provided for @editorTitleNew.
+  ///
+  /// In ja, this message translates to:
+  /// **'新規タスクを追加'**
+  String get editorTitleNew;
+
+  /// No description provided for @editorTitleEdit.
+  ///
+  /// In ja, this message translates to:
+  /// **'タスクを編集'**
+  String get editorTitleEdit;
+
+  /// No description provided for @editorSectionBasic.
+  ///
+  /// In ja, this message translates to:
+  /// **'基本情報'**
+  String get editorSectionBasic;
+
+  /// No description provided for @editorLabelName.
+  ///
+  /// In ja, this message translates to:
+  /// **'タスク名'**
+  String get editorLabelName;
+
+  /// No description provided for @editorLabelType.
+  ///
+  /// In ja, this message translates to:
+  /// **'タスク種別'**
+  String get editorLabelType;
+
+  /// No description provided for @editorLabelColor.
+  ///
+  /// In ja, this message translates to:
+  /// **'カラー'**
+  String get editorLabelColor;
+
+  /// No description provided for @editorLabelSpan.
+  ///
+  /// In ja, this message translates to:
+  /// **'実行スパン'**
+  String get editorLabelSpan;
+
+  /// No description provided for @editorLabelIcon.
+  ///
+  /// In ja, this message translates to:
+  /// **'アイコン'**
+  String get editorLabelIcon;
+
+  /// No description provided for @editorChangeIcon.
+  ///
+  /// In ja, this message translates to:
+  /// **'アイコンを変更する'**
+  String get editorChangeIcon;
+
+  /// No description provided for @editorTypeIrregular.
+  ///
+  /// In ja, this message translates to:
+  /// **'予定日を表示しない'**
+  String get editorTypeIrregular;
+
+  /// No description provided for @editorTypeIrregularDesc.
+  ///
+  /// In ja, this message translates to:
+  /// **'不定期に実行するタスクで予定日を表示しません'**
+  String get editorTypeIrregularDesc;
+
+  /// No description provided for @editorTypePeriod.
+  ///
+  /// In ja, this message translates to:
+  /// **'自動的に周期を判定'**
+  String get editorTypePeriod;
+
+  /// No description provided for @editorTypePeriodDesc.
+  ///
+  /// In ja, this message translates to:
+  /// **'タスクの実行履歴から次の予定日を表示します'**
+  String get editorTypePeriodDesc;
+
+  /// No description provided for @editorTypeScheduled.
+  ///
+  /// In ja, this message translates to:
+  /// **'周期を指定'**
+  String get editorTypeScheduled;
+
+  /// No description provided for @editorTypeScheduledDesc.
+  ///
+  /// In ja, this message translates to:
+  /// **'次の予定日までの間隔を手動で設定します'**
+  String get editorTypeScheduledDesc;
+
+  /// No description provided for @editorSpanDay.
+  ///
+  /// In ja, this message translates to:
+  /// **'日'**
+  String get editorSpanDay;
+
+  /// No description provided for @editorSpanWeek.
+  ///
+  /// In ja, this message translates to:
+  /// **'週'**
+  String get editorSpanWeek;
+
+  /// No description provided for @editorSpanMonth.
+  ///
+  /// In ja, this message translates to:
+  /// **'ヶ月'**
+  String get editorSpanMonth;
+
+  /// No description provided for @editorSpanLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'{value}{unit}ごと'**
+  String editorSpanLabel(String value, String unit);
+
+  /// No description provided for @editorSaveNew.
+  ///
+  /// In ja, this message translates to:
+  /// **'登録'**
+  String get editorSaveNew;
+
+  /// No description provided for @editorSaveEdit.
+  ///
+  /// In ja, this message translates to:
+  /// **'更新'**
+  String get editorSaveEdit;
+
+  /// No description provided for @editorIconDialogTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'アイコンを選択'**
+  String get editorIconDialogTitle;
+
+  /// No description provided for @editorColorNone.
+  ///
+  /// In ja, this message translates to:
+  /// **'なし'**
+  String get editorColorNone;
+
+  /// No description provided for @editorColorNote.
+  ///
+  /// In ja, this message translates to:
+  /// **'色を選択することでタスクのグループ分けに使えます'**
+  String get editorColorNote;
+
+  /// No description provided for @editorNameHint.
+  ///
+  /// In ja, this message translates to:
+  /// **'例：歯医者の予約'**
+  String get editorNameHint;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -65,4 +65,83 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get retry => 'Retry';
+
+  @override
+  String get editorTitleNew => 'Add Task';
+
+  @override
+  String get editorTitleEdit => 'Edit Task';
+
+  @override
+  String get editorSectionBasic => 'Basic info';
+
+  @override
+  String get editorLabelName => 'Task name';
+
+  @override
+  String get editorLabelType => 'Task type';
+
+  @override
+  String get editorLabelColor => 'Color';
+
+  @override
+  String get editorLabelSpan => 'Interval';
+
+  @override
+  String get editorLabelIcon => 'Icon';
+
+  @override
+  String get editorChangeIcon => 'Change icon';
+
+  @override
+  String get editorTypeIrregular => 'No due date';
+
+  @override
+  String get editorTypeIrregularDesc =>
+      'For irregular tasks — no due date shown';
+
+  @override
+  String get editorTypePeriod => 'Auto-detect interval';
+
+  @override
+  String get editorTypePeriodDesc => 'Next due date inferred from task history';
+
+  @override
+  String get editorTypeScheduled => 'Set interval';
+
+  @override
+  String get editorTypeScheduledDesc =>
+      'Manually set the interval to the next due date';
+
+  @override
+  String get editorSpanDay => 'days';
+
+  @override
+  String get editorSpanWeek => 'weeks';
+
+  @override
+  String get editorSpanMonth => 'months';
+
+  @override
+  String editorSpanLabel(String value, String unit) {
+    return 'Every $value $unit';
+  }
+
+  @override
+  String get editorSaveNew => 'Add';
+
+  @override
+  String get editorSaveEdit => 'Update';
+
+  @override
+  String get editorIconDialogTitle => 'Select icon';
+
+  @override
+  String get editorColorNone => 'None';
+
+  @override
+  String get editorColorNote => 'Select a color to group your tasks';
+
+  @override
+  String get editorNameHint => 'e.g. Dentist appointment';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -65,4 +65,81 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get retry => '再試行';
+
+  @override
+  String get editorTitleNew => '新規タスクを追加';
+
+  @override
+  String get editorTitleEdit => 'タスクを編集';
+
+  @override
+  String get editorSectionBasic => '基本情報';
+
+  @override
+  String get editorLabelName => 'タスク名';
+
+  @override
+  String get editorLabelType => 'タスク種別';
+
+  @override
+  String get editorLabelColor => 'カラー';
+
+  @override
+  String get editorLabelSpan => '実行スパン';
+
+  @override
+  String get editorLabelIcon => 'アイコン';
+
+  @override
+  String get editorChangeIcon => 'アイコンを変更する';
+
+  @override
+  String get editorTypeIrregular => '予定日を表示しない';
+
+  @override
+  String get editorTypeIrregularDesc => '不定期に実行するタスクで予定日を表示しません';
+
+  @override
+  String get editorTypePeriod => '自動的に周期を判定';
+
+  @override
+  String get editorTypePeriodDesc => 'タスクの実行履歴から次の予定日を表示します';
+
+  @override
+  String get editorTypeScheduled => '周期を指定';
+
+  @override
+  String get editorTypeScheduledDesc => '次の予定日までの間隔を手動で設定します';
+
+  @override
+  String get editorSpanDay => '日';
+
+  @override
+  String get editorSpanWeek => '週';
+
+  @override
+  String get editorSpanMonth => 'ヶ月';
+
+  @override
+  String editorSpanLabel(String value, String unit) {
+    return '$value$unitごと';
+  }
+
+  @override
+  String get editorSaveNew => '登録';
+
+  @override
+  String get editorSaveEdit => '更新';
+
+  @override
+  String get editorIconDialogTitle => 'アイコンを選択';
+
+  @override
+  String get editorColorNone => 'なし';
+
+  @override
+  String get editorColorNote => '色を選択することでタスクのグループ分けに使えます';
+
+  @override
+  String get editorNameHint => '例：歯医者の予約';
 }

--- a/lib/ui/editor/widgets/editor_screen.dart
+++ b/lib/ui/editor/widgets/editor_screen.dart
@@ -1,0 +1,889 @@
+import 'package:dawnbreaker/core/context_extension.dart';
+import 'package:dawnbreaker/data/model/schedule_unit.dart';
+import 'package:dawnbreaker/data/model/task_color.dart';
+import 'package:dawnbreaker/data/model/task_type.dart';
+import 'package:dawnbreaker/ui/common/error_dialog_mixin.dart';
+import 'package:dawnbreaker/ui/editor/viewmodel/editor_ui_state.dart';
+import 'package:dawnbreaker/ui/editor/viewmodel/editor_view_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+void _unfocus() => FocusManager.instance.primaryFocus?.unfocus();
+
+extension _ScheduleUnitLabel on ScheduleUnit {
+  String label(BuildContext context) => switch (this) {
+    ScheduleUnit.day => context.l10n.editorSpanDay,
+    ScheduleUnit.week => context.l10n.editorSpanWeek,
+    ScheduleUnit.month => context.l10n.editorSpanMonth,
+  };
+}
+
+class EditorScreen extends ConsumerStatefulWidget {
+  const EditorScreen({super.key, this.taskId});
+
+  final int? taskId;
+
+  @override
+  ConsumerState<EditorScreen> createState() => _EditorScreenState();
+}
+
+class _EditorScreenState extends ConsumerState<EditorScreen>
+    with ErrorDialogMixin<EditorScreen> {
+  late final _nameController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final state = ref.read(editorViewModelProvider(taskId: widget.taskId));
+      _nameController.text = state.name;
+    });
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = editorViewModelProvider(taskId: widget.taskId);
+    listenError(provider);
+
+    ref.listen(provider.select((s) => s.isSaved), (_, isSaved) {
+      if (isSaved == true) context.pop();
+    });
+
+    final uiState = ref.watch(provider);
+    final viewModel = ref.read(provider.notifier);
+    final isNew = widget.taskId == null;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          isNew ? context.l10n.editorTitleNew : context.l10n.editorTitleEdit,
+        ),
+        centerTitle: false,
+      ),
+      body: uiState.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _EditorBody(
+              uiState: uiState,
+              viewModel: viewModel,
+              nameController: _nameController,
+            ),
+      bottomNavigationBar: _SaveBar(
+        enabled: uiState.canSave && !uiState.isLoading,
+        isNew: isNew,
+        onSave: viewModel.save,
+      ),
+    );
+  }
+}
+
+class _EditorBody extends StatelessWidget {
+  const _EditorBody({
+    required this.uiState,
+    required this.viewModel,
+    required this.nameController,
+  });
+
+  final EditorUiState uiState;
+  final EditorViewModel viewModel;
+  final TextEditingController nameController;
+
+  @override
+  Widget build(BuildContext context) {
+    final padding = MediaQuery.paddingOf(context);
+    return SingleChildScrollView(
+      padding: EdgeInsets.fromLTRB(16, 8, 16, padding.bottom + 16),
+      child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _SectionHeader(context.l10n.editorSectionBasic),
+            const SizedBox(height: 8),
+            _SectionCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _IconSection(
+                    icon: uiState.icon,
+                    onChanged: viewModel.updateIcon,
+                  ),
+                  const SizedBox(height: 16),
+                  _NameField(
+                    controller: nameController,
+                    onChanged: viewModel.updateName,
+                  ),
+                  const SizedBox(height: 16),
+                  _ColorPicker(
+                    selected: uiState.color,
+                    onChanged: viewModel.updateColor,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    context.l10n.editorColorNote,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+            _SectionHeader(context.l10n.editorLabelType),
+            const SizedBox(height: 8),
+            _TypeSelector(
+              selected: uiState.type,
+              onChanged: viewModel.updateType,
+              scheduleValue: uiState.scheduleValue,
+              scheduleUnit: uiState.scheduleUnit,
+              onScheduleValueChanged: viewModel.updateScheduleValue,
+              onScheduleUnitChanged: viewModel.updateScheduleUnit,
+            ),
+          ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+          color: Theme.of(context).colorScheme.primary,
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  const _SectionCard({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.zero,
+      color: Theme.of(context).colorScheme.surfaceContainerLow,
+      elevation: 0,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(padding: const EdgeInsets.all(16), child: child),
+    );
+  }
+}
+
+class _IconSection extends StatelessWidget {
+  const _IconSection({required this.icon, required this.onChanged});
+
+  final String icon;
+  final ValueChanged<String> onChanged;
+
+  static const _presets = [
+    '📝',
+    '🏥',
+    '🦷',
+    '💊',
+    '🏋️',
+    '🧹',
+    '🛒',
+    '🚗',
+    '📚',
+    '💼',
+    '🏦',
+    '💈',
+    '🧺',
+    '🐕',
+    '🌿',
+    '🔧',
+    '📦',
+    '🎓',
+    '✈️',
+    '🏠',
+    '💡',
+    '🧪',
+    '🎯',
+    '🏃',
+    '🍳',
+    '🧘',
+    '🧴',
+    '🗓️',
+    '📞',
+    '💻',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Container(
+          width: 64,
+          height: 64,
+          decoration: BoxDecoration(
+            color: colorScheme.secondaryContainer,
+            borderRadius: BorderRadius.circular(32),
+          ),
+          child: Center(
+            child: Text(icon, style: const TextStyle(fontSize: 32)),
+          ),
+        ),
+        const SizedBox(width: 12),
+        FilledButton(
+          onPressed: () {
+            _unfocus();
+            _showIconDialog(context);
+          },
+          style: FilledButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            textStyle: Theme.of(context).textTheme.labelSmall,
+            minimumSize: Size.zero,
+          ),
+          child: Text(context.l10n.editorChangeIcon),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _showIconDialog(BuildContext context) async {
+    final selected = await showDialog<String>(
+      context: context,
+      builder: (ctx) => _IconPickerDialog(currentIcon: icon, presets: _presets),
+    );
+    if (selected != null) onChanged(selected);
+  }
+}
+
+class _IconPickerDialog extends StatefulWidget {
+  const _IconPickerDialog({required this.currentIcon, required this.presets});
+
+  final String currentIcon;
+  final List<String> presets;
+
+  @override
+  State<_IconPickerDialog> createState() => _IconPickerDialogState();
+}
+
+class _IconPickerDialogState extends State<_IconPickerDialog> {
+  late String _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = widget.currentIcon;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return AlertDialog(
+      title: Text(context.l10n.editorIconDialogTitle),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: GridView.builder(
+          shrinkWrap: true,
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 5,
+            mainAxisSpacing: 8,
+            crossAxisSpacing: 8,
+          ),
+          itemCount: widget.presets.length,
+          itemBuilder: (_, i) {
+            final emoji = widget.presets[i];
+            final isSelected = emoji == _selected;
+            return InkWell(
+              onTap: () => setState(() => _selected = emoji),
+              borderRadius: BorderRadius.circular(12),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 150),
+                decoration: BoxDecoration(
+                  color: isSelected
+                      ? colorScheme.primaryContainer
+                      : colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(12),
+                  border: isSelected
+                      ? Border.all(color: colorScheme.primary, width: 2)
+                      : null,
+                ),
+                child: Center(
+                  child: Text(emoji, style: const TextStyle(fontSize: 24)),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(context.l10n.cancel),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(_selected),
+          child: Text(context.l10n.ok),
+        ),
+      ],
+    );
+  }
+}
+
+class _NameField extends StatelessWidget {
+  const _NameField({required this.controller, required this.onChanged});
+
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      onChanged: onChanged,
+      textInputAction: TextInputAction.done,
+      decoration: InputDecoration(
+        labelText: context.l10n.editorLabelName,
+        hintText: context.l10n.editorNameHint,
+        border: const OutlineInputBorder(),
+        filled: true,
+        fillColor: Theme.of(context).colorScheme.surface,
+      ),
+    );
+  }
+}
+
+class _TypeSelector extends StatelessWidget {
+  const _TypeSelector({
+    required this.selected,
+    required this.onChanged,
+    required this.scheduleValue,
+    required this.scheduleUnit,
+    required this.onScheduleValueChanged,
+    required this.onScheduleUnitChanged,
+  });
+
+  final TaskType selected;
+  final ValueChanged<TaskType> onChanged;
+  final int scheduleValue;
+  final ScheduleUnit scheduleUnit;
+  final ValueChanged<int> onScheduleValueChanged;
+  final ValueChanged<ScheduleUnit> onScheduleUnitChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _TypeCard(
+          title: context.l10n.editorTypeIrregular,
+          description: context.l10n.editorTypeIrregularDesc,
+          icon: Icons.event_busy_outlined,
+          isSelected: selected == TaskType.irregular,
+          onTap: () => onChanged(TaskType.irregular),
+        ),
+        const SizedBox(height: 8),
+        _TypeCard(
+          title: context.l10n.editorTypePeriod,
+          description: context.l10n.editorTypePeriodDesc,
+          icon: Icons.auto_graph_outlined,
+          isSelected: selected == TaskType.period,
+          onTap: () => onChanged(TaskType.period),
+        ),
+        const SizedBox(height: 8),
+        _TypeCard(
+          title: context.l10n.editorTypeScheduled,
+          description: context.l10n.editorTypeScheduledDesc,
+          icon: Icons.repeat_outlined,
+          isSelected: selected == TaskType.scheduled,
+          onTap: () => onChanged(TaskType.scheduled),
+          expandedChild: _SpanPickerButton(
+            value: scheduleValue,
+            unit: scheduleUnit,
+            onValueChanged: onScheduleValueChanged,
+            onUnitChanged: onScheduleUnitChanged,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TypeCard extends StatelessWidget {
+  const _TypeCard({
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.isSelected,
+    required this.onTap,
+    this.expandedChild,
+  });
+
+  final String title;
+  final String description;
+  final IconData icon;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final Widget? expandedChild;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final bgColor = isSelected
+        ? colorScheme.primaryContainer
+        : colorScheme.surfaceContainerLow;
+    final borderColor = isSelected
+        ? colorScheme.primary
+        : colorScheme.outlineVariant;
+    final titleColor = isSelected
+        ? colorScheme.onPrimaryContainer
+        : colorScheme.onSurface;
+    final descColor = isSelected
+        ? colorScheme.onPrimaryContainer.withAlpha(180)
+        : colorScheme.onSurfaceVariant;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: borderColor, width: isSelected ? 2 : 1),
+      ),
+      child: InkWell(
+        // 選択済みのカードは再タップ不要なのでnullにして内部ウィジェットのタップと競合させない
+        onTap: isSelected ? null : () {
+          _unfocus();
+          onTap();
+        },
+        borderRadius: BorderRadius.circular(16),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(icon, size: 24, color: titleColor),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          style: Theme.of(context).textTheme.titleSmall
+                              ?.copyWith(
+                                color: titleColor,
+                                fontWeight: FontWeight.w600,
+                              ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          description,
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodySmall?.copyWith(color: descColor),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  AnimatedOpacity(
+                    duration: const Duration(milliseconds: 200),
+                    opacity: isSelected ? 1 : 0,
+                    child: Icon(
+                      Icons.check_circle,
+                      size: 22,
+                      color: colorScheme.primary,
+                    ),
+                  ),
+                ],
+              ),
+              if (expandedChild != null)
+                AnimatedSize(
+                  duration: const Duration(milliseconds: 280),
+                  curve: Curves.easeInOut,
+                  child: isSelected
+                      ? Padding(
+                          padding: const EdgeInsets.only(top: 16),
+                          child: expandedChild!,
+                        )
+                      : const SizedBox.shrink(),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ColorPicker extends StatelessWidget {
+  const _ColorPicker({required this.selected, required this.onChanged});
+
+  final TaskColor selected;
+  final ValueChanged<TaskColor> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: TaskColor.values.map((c) {
+        return _ColorChip(
+          taskColor: c,
+          isSelected: c == selected,
+          onTap: () => onChanged(c),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _ColorChip extends StatelessWidget {
+  const _ColorChip({
+    required this.taskColor,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final TaskColor taskColor;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final displayColor = taskColor == TaskColor.none
+        ? colorScheme.surfaceContainerHighest
+        : taskColor.color;
+
+    return GestureDetector(
+      onTap: () {
+        _unfocus();
+        onTap();
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        width: 40,
+        height: 40,
+        decoration: BoxDecoration(
+          color: displayColor,
+          shape: BoxShape.circle,
+          border: isSelected
+              ? Border.all(color: colorScheme.primary, width: 3)
+              : Border.all(color: colorScheme.outlineVariant, width: 1),
+          boxShadow: isSelected
+              ? [
+                  BoxShadow(
+                    color: colorScheme.primary.withAlpha(80),
+                    blurRadius: 6,
+                  ),
+                ]
+              : null,
+        ),
+        child: isSelected
+            ? Icon(
+                Icons.check,
+                size: 20,
+                color: taskColor == TaskColor.none
+                    ? colorScheme.onSurface
+                    : Colors.white,
+              )
+            : null,
+      ),
+    );
+  }
+}
+
+class _SpanPickerButton extends StatelessWidget {
+  const _SpanPickerButton({
+    required this.value,
+    required this.unit,
+    required this.onValueChanged,
+    required this.onUnitChanged,
+  });
+
+  final int value;
+  final ScheduleUnit unit;
+  final ValueChanged<int> onValueChanged;
+  final ValueChanged<ScheduleUnit> onUnitChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final label = context.l10n.editorSpanLabel('$value', unit.label(context));
+    return InkWell(
+      onTap: () {
+        _unfocus();
+        _showPicker(context);
+      },
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: colorScheme.outline),
+        ),
+        child: Row(
+          children: [
+            Text(
+              label,
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(color: colorScheme.onSurface),
+            ),
+            const Spacer(),
+            Icon(Icons.arrow_drop_down, color: colorScheme.onSurfaceVariant),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showPicker(BuildContext context) async {
+    final result = await showModalBottomSheet<({int value, ScheduleUnit unit})>(
+      context: context,
+      builder: (_) => _SpanPickerSheet(initialValue: value, initialUnit: unit),
+    );
+    if (result != null) {
+      onValueChanged(result.value);
+      onUnitChanged(result.unit);
+    }
+  }
+}
+
+class _SpanPickerSheet extends StatefulWidget {
+  const _SpanPickerSheet({
+    required this.initialValue,
+    required this.initialUnit,
+  });
+
+  final int initialValue;
+  final ScheduleUnit initialUnit;
+
+  @override
+  State<_SpanPickerSheet> createState() => _SpanPickerSheetState();
+}
+
+class _SpanPickerSheetState extends State<_SpanPickerSheet> {
+  static const _maxValue = 99;
+  static const _itemExtent = 52.0;
+  static const _wheelHeight = 200.0;
+
+  late int _value;
+  late ScheduleUnit _unit;
+  late final FixedExtentScrollController _valueController;
+  late final FixedExtentScrollController _unitController;
+
+  @override
+  void initState() {
+    super.initState();
+    _value = widget.initialValue;
+    _unit = widget.initialUnit;
+    _valueController = FixedExtentScrollController(
+      initialItem: widget.initialValue - 1,
+    );
+    _unitController = FixedExtentScrollController(
+      initialItem: ScheduleUnit.values.indexOf(widget.initialUnit),
+    );
+  }
+
+  @override
+  void dispose() {
+    _valueController.dispose();
+    _unitController.dispose();
+    super.dispose();
+  }
+
+  TextStyle? _wheelTextStyle(ColorScheme colorScheme, bool isSelected) {
+    return Theme.of(context).textTheme.titleLarge?.copyWith(
+      color: isSelected ? colorScheme.primary : colorScheme.onSurfaceVariant,
+    );
+  }
+
+  Positioned _fadeEdge({required Color color, required bool top}) {
+    return Positioned(
+      top: top ? 0 : null,
+      bottom: top ? null : 0,
+      left: 0,
+      right: 0,
+      child: IgnorePointer(
+        child: Container(
+          height: 72,
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: top ? Alignment.topCenter : Alignment.bottomCenter,
+              end: top ? Alignment.bottomCenter : Alignment.topCenter,
+              colors: [color, color.withAlpha(0)],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final bottomPadding = MediaQuery.paddingOf(context).bottom;
+    final surfaceColor = colorScheme.surfaceContainerLow;
+
+    return Container(
+      padding: EdgeInsets.fromLTRB(16, 12, 16, 16 + bottomPadding),
+      decoration: BoxDecoration(
+        color: surfaceColor,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 32,
+            height: 4,
+            decoration: BoxDecoration(
+              color: colorScheme.onSurfaceVariant.withAlpha(80),
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: _wheelHeight,
+            child: Stack(
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      flex: 2,
+                      child: ListWheelScrollView.useDelegate(
+                        controller: _valueController,
+                        itemExtent: _itemExtent,
+                        physics: const FixedExtentScrollPhysics(),
+                        onSelectedItemChanged: (i) =>
+                            setState(() => _value = i + 1),
+                        childDelegate: ListWheelChildBuilderDelegate(
+                          childCount: _maxValue,
+                          builder: (context, i) {
+                            final v = i + 1;
+                            return Center(
+                              child: Text(
+                                '$v',
+                                style: _wheelTextStyle(
+                                  colorScheme,
+                                  v == _value,
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      flex: 3,
+                      child: ListWheelScrollView(
+                        controller: _unitController,
+                        itemExtent: _itemExtent,
+                        physics: const FixedExtentScrollPhysics(),
+                        onSelectedItemChanged: (i) =>
+                            setState(() => _unit = ScheduleUnit.values[i]),
+                        children: ScheduleUnit.values.map((u) {
+                          return Center(
+                            child: Text(
+                              u.label(context),
+                              style: _wheelTextStyle(colorScheme, u == _unit),
+                            ),
+                          );
+                        }).toList(),
+                      ),
+                    ),
+                  ],
+                ),
+                Positioned(
+                  top: (_wheelHeight - _itemExtent) / 2,
+                  left: 0,
+                  right: 0,
+                  child: IgnorePointer(
+                    child: Container(
+                      height: _itemExtent,
+                      decoration: BoxDecoration(
+                        color: colorScheme.primaryContainer.withAlpha(80),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                  ),
+                ),
+                _fadeEdge(color: surfaceColor, top: true),
+                _fadeEdge(color: surfaceColor, top: false),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: () =>
+                Navigator.of(context).pop((value: _value, unit: _unit)),
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(48),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+            child: Text(context.l10n.ok),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SaveBar extends StatelessWidget {
+  const _SaveBar({
+    required this.enabled,
+    required this.isNew,
+    required this.onSave,
+  });
+
+  final bool enabled;
+  final bool isNew;
+  final VoidCallback onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomPadding = MediaQuery.paddingOf(context).bottom;
+    return Container(
+      padding: EdgeInsets.fromLTRB(16, 12, 16, 12 + bottomPadding),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        border: Border(
+          top: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
+        ),
+      ),
+      child: FilledButton(
+        onPressed: enabled ? () {
+            _unfocus();
+            onSave();
+          } : null,
+        style: FilledButton.styleFrom(
+          minimumSize: const Size.fromHeight(52),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+        child: Text(
+          isNew ? context.l10n.editorSaveNew : context.l10n.editorSaveEdit,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/editor/widgets/editor_screen.dart
+++ b/lib/ui/editor/widgets/editor_screen.dart
@@ -5,6 +5,7 @@ import 'package:dawnbreaker/data/model/task_type.dart';
 import 'package:dawnbreaker/ui/common/error_dialog_mixin.dart';
 import 'package:dawnbreaker/ui/editor/viewmodel/editor_ui_state.dart';
 import 'package:dawnbreaker/ui/editor/viewmodel/editor_view_model.dart';
+import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -189,39 +190,6 @@ class _IconSection extends StatelessWidget {
   final String icon;
   final ValueChanged<String> onChanged;
 
-  static const _presets = [
-    '📝',
-    '🏥',
-    '🦷',
-    '💊',
-    '🏋️',
-    '🧹',
-    '🛒',
-    '🚗',
-    '📚',
-    '💼',
-    '🏦',
-    '💈',
-    '🧺',
-    '🐕',
-    '🌿',
-    '🔧',
-    '📦',
-    '🎓',
-    '✈️',
-    '🏠',
-    '💡',
-    '🧪',
-    '🎯',
-    '🏃',
-    '🍳',
-    '🧘',
-    '🧴',
-    '🗓️',
-    '📞',
-    '💻',
-  ];
-
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -241,7 +209,7 @@ class _IconSection extends StatelessWidget {
         ),
         const SizedBox(width: 12),
         FilledButton(
-          onPressed: () => _showIconDialog(context),
+          onPressed: () => _showEmojiPicker(context),
           style: FilledButton.styleFrom(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             tapTargetSize: MaterialTapTargetSize.shrinkWrap,
@@ -254,87 +222,43 @@ class _IconSection extends StatelessWidget {
     );
   }
 
-  Future<void> _showIconDialog(BuildContext context) async {
-    final selected = await showDialog<String>(
-      context: context,
-      builder: (ctx) => _IconPickerDialog(currentIcon: icon, presets: _presets),
-    );
-    if (selected != null) onChanged(selected);
-  }
-}
-
-class _IconPickerDialog extends StatefulWidget {
-  const _IconPickerDialog({required this.currentIcon, required this.presets});
-
-  final String currentIcon;
-  final List<String> presets;
-
-  @override
-  State<_IconPickerDialog> createState() => _IconPickerDialogState();
-}
-
-class _IconPickerDialogState extends State<_IconPickerDialog> {
-  late String _selected;
-
-  @override
-  void initState() {
-    super.initState();
-    _selected = widget.currentIcon;
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Future<void> _showEmojiPicker(BuildContext context) async {
     final colorScheme = Theme.of(context).colorScheme;
-    return AlertDialog(
-      title: Text(context.l10n.editorIconDialogTitle),
-      content: SizedBox(
-        width: double.maxFinite,
-        child: GridView.builder(
-          shrinkWrap: true,
-          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 5,
-            mainAxisSpacing: 8,
-            crossAxisSpacing: 8,
-          ),
-          itemCount: widget.presets.length,
-          itemBuilder: (_, i) {
-            final emoji = widget.presets[i];
-            final isSelected = emoji == _selected;
-            return InkWell(
-              onTap: () => setState(() => _selected = emoji),
-              borderRadius: BorderRadius.circular(12),
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 150),
-                decoration: BoxDecoration(
-                  color: isSelected
-                      ? colorScheme.primaryContainer
-                      : colorScheme.surfaceContainerHighest,
-                  borderRadius: BorderRadius.circular(12),
-                  border: isSelected
-                      ? Border.all(color: colorScheme.primary, width: 2)
-                      : null,
-                ),
-                child: Center(
-                  child: Text(emoji, style: const TextStyle(fontSize: 24)),
-                ),
-              ),
-            );
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (ctx) => EmojiPicker(
+          onEmojiSelected: (_, emoji) {
+            onChanged(emoji.emoji);
+            Navigator.of(ctx).pop();
           },
+          config: Config(
+            height: 256,
+            checkPlatformCompatibility: true,
+            emojiViewConfig: EmojiViewConfig(
+              backgroundColor: colorScheme.surfaceContainerLow,
+              columns: 8,
+              emojiSizeMax: 40,
+              gridPadding: const EdgeInsets.fromLTRB(8, 8, 8, 16),
+            ),
+            categoryViewConfig: CategoryViewConfig(
+              backgroundColor: colorScheme.surfaceContainerLow,
+              iconColor: colorScheme.onSurfaceVariant,
+              iconColorSelected: colorScheme.primary,
+              indicatorColor: colorScheme.primary,
+              backspaceColor: colorScheme.onSurfaceVariant,
+              dividerColor: colorScheme.outlineVariant,
+            ),
+            bottomActionBarConfig: const BottomActionBarConfig(
+              enabled: false,
+            ),
+          ),
         ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(context.l10n.cancel),
-        ),
-        FilledButton(
-          onPressed: () => Navigator.of(context).pop(_selected),
-          child: Text(context.l10n.ok),
-        ),
-      ],
     );
   }
 }
+
 
 class _NameField extends StatelessWidget {
   const _NameField({required this.controller, required this.onChanged});

--- a/lib/ui/editor/widgets/editor_screen.dart
+++ b/lib/ui/editor/widgets/editor_screen.dart
@@ -9,8 +9,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-void _unfocus() => FocusManager.instance.primaryFocus?.unfocus();
-
 extension _ScheduleUnitLabel on ScheduleUnit {
   String label(BuildContext context) => switch (this) {
     ScheduleUnit.day => context.l10n.editorSpanDay,
@@ -100,50 +98,50 @@ class _EditorBody extends StatelessWidget {
     return SingleChildScrollView(
       padding: EdgeInsets.fromLTRB(16, 8, 16, padding.bottom + 16),
       child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _SectionHeader(context.l10n.editorSectionBasic),
-            const SizedBox(height: 8),
-            _SectionCard(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _IconSection(
-                    icon: uiState.icon,
-                    onChanged: viewModel.updateIcon,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SectionHeader(context.l10n.editorSectionBasic),
+          const SizedBox(height: 8),
+          _SectionCard(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _IconSection(
+                  icon: uiState.icon,
+                  onChanged: viewModel.updateIcon,
+                ),
+                const SizedBox(height: 16),
+                _NameField(
+                  controller: nameController,
+                  onChanged: viewModel.updateName,
+                ),
+                const SizedBox(height: 16),
+                _ColorPicker(
+                  selected: uiState.color,
+                  onChanged: viewModel.updateColor,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  context.l10n.editorColorNote,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
-                  const SizedBox(height: 16),
-                  _NameField(
-                    controller: nameController,
-                    onChanged: viewModel.updateName,
-                  ),
-                  const SizedBox(height: 16),
-                  _ColorPicker(
-                    selected: uiState.color,
-                    onChanged: viewModel.updateColor,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    context.l10n.editorColorNote,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
+                ),
+              ],
             ),
-            const SizedBox(height: 24),
-            _SectionHeader(context.l10n.editorLabelType),
-            const SizedBox(height: 8),
-            _TypeSelector(
-              selected: uiState.type,
-              onChanged: viewModel.updateType,
-              scheduleValue: uiState.scheduleValue,
-              scheduleUnit: uiState.scheduleUnit,
-              onScheduleValueChanged: viewModel.updateScheduleValue,
-              onScheduleUnitChanged: viewModel.updateScheduleUnit,
-            ),
-          ],
+          ),
+          const SizedBox(height: 24),
+          _SectionHeader(context.l10n.editorLabelType),
+          const SizedBox(height: 8),
+          _TypeSelector(
+            selected: uiState.type,
+            onChanged: viewModel.updateType,
+            scheduleValue: uiState.scheduleValue,
+            scheduleUnit: uiState.scheduleUnit,
+            onScheduleValueChanged: viewModel.updateScheduleValue,
+            onScheduleUnitChanged: viewModel.updateScheduleUnit,
+          ),
+        ],
       ),
     );
   }
@@ -243,10 +241,7 @@ class _IconSection extends StatelessWidget {
         ),
         const SizedBox(width: 12),
         FilledButton(
-          onPressed: () {
-            _unfocus();
-            _showIconDialog(context);
-          },
+          onPressed: () => _showIconDialog(context),
           style: FilledButton.styleFrom(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             tapTargetSize: MaterialTapTargetSize.shrinkWrap,
@@ -360,6 +355,7 @@ class _NameField extends StatelessWidget {
         filled: true,
         fillColor: Theme.of(context).colorScheme.surface,
       ),
+      onTapOutside: (_) => FocusManager.instance.primaryFocus?.unfocus(),
     );
   }
 }
@@ -462,10 +458,7 @@ class _TypeCard extends StatelessWidget {
       ),
       child: InkWell(
         // 選択済みのカードは再タップ不要なのでnullにして内部ウィジェットのタップと競合させない
-        onTap: isSelected ? null : () {
-          _unfocus();
-          onTap();
-        },
+        onTap: isSelected ? null : onTap,
         borderRadius: BorderRadius.circular(16),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
@@ -576,10 +569,7 @@ class _ColorChip extends StatelessWidget {
         : taskColor.color;
 
     return GestureDetector(
-      onTap: () {
-        _unfocus();
-        onTap();
-      },
+      onTap: onTap,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 150),
         width: 40,
@@ -631,10 +621,7 @@ class _SpanPickerButton extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final label = context.l10n.editorSpanLabel('$value', unit.label(context));
     return InkWell(
-      onTap: () {
-        _unfocus();
-        _showPicker(context);
-      },
+      onTap: () => _showPicker(context),
       borderRadius: BorderRadius.circular(12),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -876,10 +863,7 @@ class _SaveBar extends StatelessWidget {
         ),
       ),
       child: FilledButton(
-        onPressed: enabled ? () {
-            _unfocus();
-            onSave();
-          } : null,
+        onPressed: enabled ? onSave : null,
         style: FilledButton.styleFrom(
           minimumSize: const Size.fromHeight(52),
           shape: RoundedRectangleBorder(

--- a/lib/ui/editor/widgets/editor_screen.dart
+++ b/lib/ui/editor/widgets/editor_screen.dart
@@ -229,36 +229,33 @@ class _IconSection extends StatelessWidget {
       isScrollControlled: true,
       useSafeArea: true,
       builder: (ctx) => EmojiPicker(
-          onEmojiSelected: (_, emoji) {
-            onChanged(emoji.emoji);
-            Navigator.of(ctx).pop();
-          },
-          config: Config(
-            height: 256,
-            checkPlatformCompatibility: true,
-            emojiViewConfig: EmojiViewConfig(
-              backgroundColor: colorScheme.surfaceContainerLow,
-              columns: 8,
-              emojiSizeMax: 40,
-              gridPadding: const EdgeInsets.fromLTRB(8, 8, 8, 16),
-            ),
-            categoryViewConfig: CategoryViewConfig(
-              backgroundColor: colorScheme.surfaceContainerLow,
-              iconColor: colorScheme.onSurfaceVariant,
-              iconColorSelected: colorScheme.primary,
-              indicatorColor: colorScheme.primary,
-              backspaceColor: colorScheme.onSurfaceVariant,
-              dividerColor: colorScheme.outlineVariant,
-            ),
-            bottomActionBarConfig: const BottomActionBarConfig(
-              enabled: false,
-            ),
+        onEmojiSelected: (_, emoji) {
+          onChanged(emoji.emoji);
+          Navigator.of(ctx).pop();
+        },
+        config: Config(
+          height: 256,
+          checkPlatformCompatibility: true,
+          emojiViewConfig: EmojiViewConfig(
+            backgroundColor: colorScheme.surfaceContainerLow,
+            columns: 8,
+            emojiSizeMax: 40,
+            gridPadding: const EdgeInsets.fromLTRB(8, 8, 8, 16),
           ),
+          categoryViewConfig: CategoryViewConfig(
+            backgroundColor: colorScheme.surfaceContainerLow,
+            iconColor: colorScheme.onSurfaceVariant,
+            iconColorSelected: colorScheme.primary,
+            indicatorColor: colorScheme.primary,
+            backspaceColor: colorScheme.onSurfaceVariant,
+            dividerColor: colorScheme.outlineVariant,
+          ),
+          bottomActionBarConfig: const BottomActionBarConfig(enabled: false),
         ),
+      ),
     );
   }
 }
-
 
 class _NameField extends StatelessWidget {
   const _NameField({required this.controller, required this.onChanged});
@@ -372,79 +369,84 @@ class _TypeCard extends StatelessWidget {
         ? colorScheme.onPrimaryContainer.withAlpha(180)
         : colorScheme.onSurfaceVariant;
 
-    return AnimatedContainer(
-      duration: const Duration(milliseconds: 200),
-      curve: Curves.easeInOut,
-      decoration: BoxDecoration(
-        color: bgColor,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: borderColor, width: 2),
-      ),
-      child: InkWell(
-        // 選択済みのカードは再タップ不要なのでnullにして内部ウィジェットのタップと競合させない
-        onTap: isSelected ? null : onTap,
-        borderRadius: BorderRadius.circular(16),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Icon(icon, size: 24, color: titleColor),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          title,
-                          style: Theme.of(context).textTheme.titleSmall
-                              ?.copyWith(
-                                color: titleColor,
-                                fontWeight: FontWeight.w600,
-                              ),
-                        ),
-                        const SizedBox(height: 2),
-                        Text(
-                          description,
-                          style: Theme.of(
-                            context,
-                          ).textTheme.bodySmall?.copyWith(color: descColor),
-                        ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  AnimatedOpacity(
-                    duration: const Duration(milliseconds: 200),
-                    opacity: isSelected ? 1 : 0,
-                    child: Icon(
-                      Icons.check_circle,
-                      size: 22,
-                      color: colorScheme.primary,
-                    ),
-                  ),
-                ],
-              ),
-              if (expandedChild != null)
+    return Semantics(
+      inMutuallyExclusiveGroup: true,
+      checked: isSelected,
+      label: title,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeInOut,
+        decoration: BoxDecoration(
+          color: bgColor,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: borderColor, width: 2),
+        ),
+        child: InkWell(
+          // 選択済みのカードは再タップ不要なのでnullにして内部ウィジェットのタップと競合させない
+          onTap: isSelected ? null : onTap,
+          borderRadius: BorderRadius.circular(16),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
                 Row(
                   children: [
+                    Icon(icon, size: 24, color: titleColor),
+                    const SizedBox(width: 16),
                     Expanded(
-                      child: AnimatedSize(
-                        duration: const Duration(milliseconds: 280),
-                        curve: Curves.easeInOut,
-                        child: isSelected
-                            ? Padding(
-                                padding: const EdgeInsets.only(top: 16),
-                                child: expandedChild!,
-                              )
-                            : const SizedBox.shrink(),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            title,
+                            style: Theme.of(context).textTheme.titleSmall
+                                ?.copyWith(
+                                  color: titleColor,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            description,
+                            style: Theme.of(
+                              context,
+                            ).textTheme.bodySmall?.copyWith(color: descColor),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    AnimatedOpacity(
+                      duration: const Duration(milliseconds: 200),
+                      opacity: isSelected ? 1 : 0,
+                      child: Icon(
+                        Icons.check_circle,
+                        size: 22,
+                        color: colorScheme.primary,
                       ),
                     ),
                   ],
                 ),
-            ],
+                if (expandedChild != null)
+                  Row(
+                    children: [
+                      Expanded(
+                        child: AnimatedSize(
+                          duration: const Duration(milliseconds: 280),
+                          curve: Curves.easeInOut,
+                          child: isSelected
+                              ? Padding(
+                                  padding: const EdgeInsets.only(top: 16),
+                                  child: expandedChild!,
+                                )
+                              : const SizedBox.shrink(),
+                        ),
+                      ),
+                    ],
+                  ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/ui/editor/widgets/editor_screen.dart
+++ b/lib/ui/editor/widgets/editor_screen.dart
@@ -458,7 +458,7 @@ class _TypeCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: bgColor,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: borderColor, width: isSelected ? 2 : 1),
+        border: Border.all(color: borderColor, width: 2),
       ),
       child: InkWell(
         // 選択済みのカードは再タップ不要なのでnullにして内部ウィジェットのタップと競合させない
@@ -511,15 +511,21 @@ class _TypeCard extends StatelessWidget {
                 ],
               ),
               if (expandedChild != null)
-                AnimatedSize(
-                  duration: const Duration(milliseconds: 280),
-                  curve: Curves.easeInOut,
-                  child: isSelected
-                      ? Padding(
-                          padding: const EdgeInsets.only(top: 16),
-                          child: expandedChild!,
-                        )
-                      : const SizedBox.shrink(),
+                Row(
+                  children: [
+                    Expanded(
+                      child: AnimatedSize(
+                        duration: const Duration(milliseconds: 280),
+                        curve: Curves.easeInOut,
+                        child: isSelected
+                            ? Padding(
+                                padding: const EdgeInsets.only(top: 16),
+                                child: expandedChild!,
+                              )
+                            : const SizedBox.shrink(),
+                      ),
+                    ),
+                  ],
                 ),
             ],
           ),

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -53,11 +53,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         ),
         opacity: 0.20,
       ),
-      body: GestureDetector(
-        onTap: () => FocusScope.of(context).unfocus(),
-        behavior: HitTestBehavior.translucent,
-        child: _bodyWidget(context, uiState),
-      ),
+      body: _bodyWidget(context, uiState),
     );
   }
 
@@ -124,6 +120,7 @@ class _SearchBarField extends StatelessWidget {
       child: TextField(
         controller: controller,
         onChanged: onChanged,
+        onTapOutside: (_) => FocusManager.instance.primaryFocus?.unfocus(),
         decoration: InputDecoration(
           hintText: context.l10n.homeSearchHint,
           prefixIcon: const Icon(Icons.search),
@@ -160,7 +157,10 @@ class _TaskListView extends StatelessWidget {
         bottom: 80 + 8 + bottomPadding,
       ),
       itemCount: tasks.length,
-      itemBuilder: (context, index) => TaskListItem(task: tasks[index]),
+      itemBuilder: (context, index) => TaskListItem(
+        task: tasks[index],
+        onTap: () => context.push('/editor', extra: tasks[index].id),
+      ),
     );
   }
 }

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -6,6 +6,7 @@ import 'package:dawnbreaker/ui/home/viewmodel/home_view_model.dart';
 import 'package:dawnbreaker/ui/home/widgets/task_list_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -36,7 +37,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
     return Scaffold(
       floatingActionButton: FloatingActionButton(
-        onPressed: () {},
+        onPressed: () => context.push('/editor'),
         child: const Icon(Icons.add),
       ),
       extendBodyBehindAppBar: true,

--- a/lib/ui/home/widgets/task_list_item.dart
+++ b/lib/ui/home/widgets/task_list_item.dart
@@ -5,9 +5,10 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class TaskListItem extends StatelessWidget {
-  const TaskListItem({super.key, required this.task});
+  const TaskListItem({super.key, required this.task, required this.onTap});
 
   final TaskItem task;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +26,7 @@ class TaskListItem extends StatelessWidget {
         side: BorderSide(color: colorScheme.outlineVariant),
       ),
       child: InkWell(
-        onTap: () {},
+        onTap: onTap,
         borderRadius: cardRadius,
         child: IntrinsicHeight(
           child: Row(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.8"
+  emoji_picker_flutter:
+    dependency: "direct main"
+    description:
+      name: emoji_picker_flutter
+      sha256: "984d3e9b9cf3175df9a868ce4a2d9611491e80e5d3b8e2b1e8991a4998972885"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.0"
   fake_async:
     dependency: transitive
     description:
@@ -669,6 +677,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.3"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.23"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   drift: ^2.31.0
   drift_flutter: ^0.2.8
   path_provider: ^2.1.5
+  emoji_picker_flutter: ^4.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- アイコン・タスク名・カラー・タスク種別・周期の編集UIを実装
- `AnimatedSize` でタスク種別カードの周期ピッカーを展開/収納
- `ListWheelScrollView` のドラムピッカーで周期（数値＋単位）を選択
- キーボードのフォーカス外しを各インタラクション箇所で個別に `_unfocus()` を呼ぶ方式で実装
- l10n に EditorScreen 用文言を追加（ja/en）

## Screen Shot

<img width="350" alt="screenshot_20260419203936" src="https://github.com/user-attachments/assets/76eac0b3-b66c-459b-9d1b-f28da80ffe24" />