### PR TITLE
タスク履歴にコメント機能を追加

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
     packaging {
         resources.excludes += "META-INF/*.md"
     }
-    namespace = "que.sera.sera.dqnbreaker.dawnbreaker"
+    namespace = "que.sera.sera.dawnbreaker"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "que.sera.sera.dqnbreaker.dawnbreaker"
+        applicationId = "que.sera.sera.dawnbreaker"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/kotlin/que/sera/sera/dawnbreaker/MainActivity.kt
+++ b/android/app/src/main/kotlin/que/sera/sera/dawnbreaker/MainActivity.kt
@@ -1,8 +1,8 @@
-package que.sera.sera.dqnbreaker.dawnbreaker
+package que.sera.sera.dawnbreaker
 
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
-import que.sera.sera.dqnbreaker.dawnbreaker.util.FuriganaTranslate
+import que.sera.sera.dawnbreaker.util.FuriganaTranslate
 
 class MainActivity : FlutterActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {

--- a/android/app/src/main/kotlin/que/sera/sera/dawnbreaker/util/FuriganaTranslate.kt
+++ b/android/app/src/main/kotlin/que/sera/sera/dawnbreaker/util/FuriganaTranslate.kt
@@ -1,4 +1,4 @@
-package que.sera.sera.dqnbreaker.dawnbreaker.util
+package que.sera.sera.dawnbreaker.util
 
 import com.atilika.kuromoji.ipadic.Tokenizer
 import io.flutter.embedding.engine.plugins.FlutterPlugin

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,63 @@
+PODS:
+  - emoji_picker_flutter (0.0.1):
+    - Flutter
+  - Flutter (1.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - sqlite3 (3.52.0):
+    - sqlite3/common (= 3.52.0)
+  - sqlite3/common (3.52.0)
+  - sqlite3/dbstatvtab (3.52.0):
+    - sqlite3/common
+  - sqlite3/fts5 (3.52.0):
+    - sqlite3/common
+  - sqlite3/math (3.52.0):
+    - sqlite3/common
+  - sqlite3/perf-threadsafe (3.52.0):
+    - sqlite3/common
+  - sqlite3/rtree (3.52.0):
+    - sqlite3/common
+  - sqlite3/session (3.52.0):
+    - sqlite3/common
+  - sqlite3_flutter_libs (0.0.1):
+    - Flutter
+    - FlutterMacOS
+    - sqlite3 (~> 3.52.0)
+    - sqlite3/dbstatvtab
+    - sqlite3/fts5
+    - sqlite3/math
+    - sqlite3/perf-threadsafe
+    - sqlite3/rtree
+    - sqlite3/session
+
+DEPENDENCIES:
+  - emoji_picker_flutter (from `.symlinks/plugins/emoji_picker_flutter/ios`)
+  - Flutter (from `Flutter`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
+
+SPEC REPOS:
+  trunk:
+    - sqlite3
+
+EXTERNAL SOURCES:
+  emoji_picker_flutter:
+    :path: ".symlinks/plugins/emoji_picker_flutter/ios"
+  Flutter:
+    :path: Flutter
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  sqlite3_flutter_libs:
+    :path: ".symlinks/plugins/sqlite3_flutter_libs/darwin"
+
+SPEC CHECKSUMS:
+  emoji_picker_flutter: 8e50ec5caac456a23a78637e02c6293ea0ac8771
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
+  sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
+  sqlite3_flutter_libs: f9114e4bbe1f2e03dd543373c53d23245982ca13
+
+PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+
+COCOAPODS: 1.15.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -9,7 +9,9 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
+		34D60E071422B2863D850991 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D2A7AB359092736CB66AADA /* Pods_RunnerTests.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		602E529025BD84D3F9C5D193 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E36B29D7FD3E6B7CE018CECF /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -44,13 +46,17 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		177A2F3974D4CA5FAF54DD2A /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		67249AB49F9FC83B35D28FA3 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		6D1842BF55176CAC6F3AFABE /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		7D2A7AB359092736CB66AADA /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -58,6 +64,10 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B6E77DA7C4D867595E78B1D8 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		C8DCE72EEC010EA579FD4003 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		E36B29D7FD3E6B7CE018CECF /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EE538F4736159061DEFE5CA4 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		FBF0FB452F8CE82C0018646D /* FuriganaTranslate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuriganaTranslate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -66,12 +76,35 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				602E529025BD84D3F9C5D193 /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A142AD5622A9E54EC8921B84 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				34D60E071422B2863D850991 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2DDB3D205EA46D19778C4BEC /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				177A2F3974D4CA5FAF54DD2A /* Pods-Runner.debug.xcconfig */,
+				EE538F4736159061DEFE5CA4 /* Pods-Runner.release.xcconfig */,
+				6D1842BF55176CAC6F3AFABE /* Pods-Runner.profile.xcconfig */,
+				C8DCE72EEC010EA579FD4003 /* Pods-RunnerTests.debug.xcconfig */,
+				67249AB49F9FC83B35D28FA3 /* Pods-RunnerTests.release.xcconfig */,
+				B6E77DA7C4D867595E78B1D8 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		331C8082294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -98,6 +131,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				2DDB3D205EA46D19778C4BEC /* Pods */,
+				FC5F7DA22F73A2926B4788C4 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -135,6 +170,15 @@
 			path = Util;
 			sourceTree = "<group>";
 		};
+		FC5F7DA22F73A2926B4788C4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E36B29D7FD3E6B7CE018CECF /* Pods_Runner.framework */,
+				7D2A7AB359092736CB66AADA /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -142,8 +186,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				730BE393D3FC955AE3DB66BD /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				A142AD5622A9E54EC8921B84 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -159,12 +205,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				BB31F710152376C91094240C /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				81F2EC741A4F9AF738584061 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -252,6 +300,45 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		730BE393D3FC955AE3DB66BD /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		81F2EC741A4F9AF738584061 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -266,6 +353,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		BB31F710152376C91094240C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -384,7 +493,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dqnbreaker.dawnbreaker;
+				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dawnbreaker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -394,13 +503,14 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C8DCE72EEC010EA579FD4003 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dqnbreaker.dawnbreaker.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dawnbreaker.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -411,13 +521,14 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 67249AB49F9FC83B35D28FA3 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dqnbreaker.dawnbreaker.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dawnbreaker.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -426,13 +537,14 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B6E77DA7C4D867595E78B1D8 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dqnbreaker.dawnbreaker.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dawnbreaker.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -563,7 +675,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dqnbreaker.dawnbreaker;
+				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dawnbreaker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -585,7 +697,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dqnbreaker.dawnbreaker;
+				PRODUCT_BUNDLE_IDENTIFIER = que.sera.sera.dawnbreaker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/lib/data/database/tables/task_executions_table.dart
+++ b/lib/data/database/tables/task_executions_table.dart
@@ -12,4 +12,6 @@ class TaskExecutions extends Table {
       integer().references(TaskDefinitions, #id, onDelete: KeyAction.cascade)();
 
   DateTimeColumn get executedAt => dateTime()();
+
+  TextColumn get comment => text().nullable()();
 }

--- a/lib/data/model/task_history.dart
+++ b/lib/data/model/task_history.dart
@@ -4,6 +4,9 @@ part 'task_history.freezed.dart';
 
 @freezed
 abstract class TaskHistory with _$TaskHistory {
-  const factory TaskHistory({required int id, required DateTime executedAt}) =
-      _TaskHistory;
+  const factory TaskHistory({
+    required int id,
+    required DateTime executedAt,
+    required String? comment,
+  }) =_TaskHistory;
 }

--- a/lib/data/repository/task/task_repository.dart
+++ b/lib/data/repository/task/task_repository.dart
@@ -31,7 +31,11 @@ abstract interface class TaskRepository {
     ScheduleUnit? scheduleUnit,
   });
 
-  Future<TaskHistory> recordExecution(int taskId, {required DateTime executedAt});
+  Future<TaskHistory> recordExecution(
+    int taskId, {
+    required DateTime executedAt,
+    String? comment,
+  });
 
   Future<void> deleteExecution(int executionId);
 

--- a/lib/data/repository/task/task_repository.dart
+++ b/lib/data/repository/task/task_repository.dart
@@ -37,6 +37,12 @@ abstract interface class TaskRepository {
     String? comment,
   });
 
+  Future<void> updateExecution(
+    int executionId, {
+    required DateTime executedAt,
+    String? comment,
+  });
+
   Future<void> deleteExecution(int executionId);
 
   Future<void> deleteTask(int taskId);

--- a/lib/data/repository/task/task_repository_impl.dart
+++ b/lib/data/repository/task/task_repository_impl.dart
@@ -39,12 +39,12 @@ class TaskRepositoryImpl implements TaskRepository {
 
   @override
   Stream<TaskItem?> watchTaskById(int taskId) {
-    return _baseTaskQuery(where: _db.taskDefinitions.id.equals(taskId))
-        .watch()
-        .map((rows) {
-          if (rows.isEmpty) return null;
-          return _buildTaskItemFromRows(rows);
-        });
+    return _baseTaskQuery(
+      where: _db.taskDefinitions.id.equals(taskId),
+    ).watch().map((rows) {
+      if (rows.isEmpty) return null;
+      return _buildTaskItemFromRows(rows);
+    });
   }
 
   @override
@@ -109,7 +109,13 @@ class TaskRepositoryImpl implements TaskRepository {
     final taskHistory = rows
         .map((r) => r.readTableOrNull(_db.taskExecutions))
         .nonNulls
-        .map((e) => TaskHistory(id: e.id, executedAt: e.executedAt))
+        .map(
+          (e) => TaskHistory(
+            id: e.id,
+            executedAt: e.executedAt,
+            comment: e.comment,
+          ),
+        )
         .toList();
 
     return switch (def.taskType) {
@@ -205,6 +211,7 @@ class TaskRepositoryImpl implements TaskRepository {
   Future<TaskHistory> recordExecution(
     int taskId, {
     required DateTime executedAt,
+    String? comment,
   }) async {
     try {
       final id = await _db
@@ -215,7 +222,7 @@ class TaskRepositoryImpl implements TaskRepository {
               executedAt: executedAt,
             ),
           );
-      return TaskHistory(id: id, executedAt: executedAt);
+      return TaskHistory(id: id, executedAt: executedAt, comment: comment);
     } catch (e) {
       throw TaskSaveException(e.toString());
     }

--- a/lib/data/repository/task/task_repository_impl.dart
+++ b/lib/data/repository/task/task_repository_impl.dart
@@ -230,6 +230,26 @@ class TaskRepositoryImpl implements TaskRepository {
   }
 
   @override
+  Future<void> updateExecution(
+    int executionId, {
+    required DateTime executedAt,
+    String? comment,
+  }) async {
+    try {
+      await (_db.update(_db.taskExecutions)
+            ..where((t) => t.id.equals(executionId)))
+          .write(
+            TaskExecutionsCompanion(
+              executedAt: Value(executedAt),
+              comment: Value(comment),
+            ),
+          );
+    } catch (e) {
+      throw TaskUpdateException(e.toString());
+    }
+  }
+
+  @override
   Future<void> deleteExecution(int executionId) async {
     try {
       await (_db.delete(

--- a/lib/data/repository/task/task_repository_impl.dart
+++ b/lib/data/repository/task/task_repository_impl.dart
@@ -220,6 +220,7 @@ class TaskRepositoryImpl implements TaskRepository {
             TaskExecutionsCompanion.insert(
               taskDefinitionId: taskId,
               executedAt: executedAt,
+              comment: Value(comment),
             ),
           );
       return TaskHistory(id: id, executedAt: executedAt, comment: comment);

--- a/lib/data/repository/task/task_repository_impl.dart
+++ b/lib/data/repository/task/task_repository_impl.dart
@@ -359,6 +359,7 @@ class TaskRepositoryImpl implements TaskRepository {
               (history) => TaskExecutionsCompanion.insert(
                 taskDefinitionId: id,
                 executedAt: history.executedAt,
+                comment: Value(history.comment),
               ),
             ),
           );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -15,6 +15,7 @@
   "homeComplete": "Done",
   "homeCompleteSheetTitle": "Complete task",
   "homeCompleteRecord": "Record completion",
+  "homeCompleteCommentPlaceholder": "Add a comment (optional)",
   "homeCompleteSuccess": "Marked \"{name}\" as complete",
   "@homeCompleteSuccess": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -119,6 +119,5 @@
       "value": { "type": "int" },
       "unit": { "type": "String" }
     }
-  },
-  "appDetailCommentPlaceholder": "Comment"
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -119,5 +119,6 @@
       "value": { "type": "int" },
       "unit": { "type": "String" }
     }
-  }
+  },
+  "appDetailUpdateHistorySuccess": "History updated"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -119,5 +119,6 @@
       "value": { "type": "int" },
       "unit": { "type": "String" }
     }
-  }
+  },
+  "appDetailUpdateHistorySuccess": "履歴を更新しました"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -119,6 +119,5 @@
       "value": { "type": "int" },
       "unit": { "type": "String" }
     }
-  },
-  "appDetailCommentPlaceholder": "コメント"
+  }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -15,6 +15,7 @@
   "homeComplete": "完了",
   "homeCompleteSheetTitle": "タスクを完了",
   "homeCompleteRecord": "完了を記録",
+  "homeCompleteCommentPlaceholder": "コメントを入力（任意）",
   "homeCompleteSuccess": "「{name}」の完了を記録しました",
   "@homeCompleteSuccess": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -535,12 +535,6 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'定期 {value}{unit}'**
   String appDetailTypeBadgeScheduled(int value, String unit);
-
-  /// No description provided for @appDetailCommentPlaceholder.
-  ///
-  /// In ja, this message translates to:
-  /// **'コメント'**
-  String get appDetailCommentPlaceholder;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -188,6 +188,12 @@ abstract class AppLocalizations {
   /// **'完了を記録'**
   String get homeCompleteRecord;
 
+  /// No description provided for @homeCompleteCommentPlaceholder.
+  ///
+  /// In ja, this message translates to:
+  /// **'コメントを入力（任意）'**
+  String get homeCompleteCommentPlaceholder;
+
   /// No description provided for @homeCompleteSuccess.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -535,6 +535,12 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'定期 {value}{unit}'**
   String appDetailTypeBadgeScheduled(int value, String unit);
+
+  /// No description provided for @appDetailUpdateHistorySuccess.
+  ///
+  /// In ja, this message translates to:
+  /// **'履歴を更新しました'**
+  String get appDetailUpdateHistorySuccess;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -245,4 +245,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String appDetailTypeBadgeScheduled(int value, String unit) {
     return 'Every $value $unit';
   }
+
+  @override
+  String get appDetailUpdateHistorySuccess => 'History updated';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -54,6 +54,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeCompleteRecord => 'Record completion';
 
   @override
+  String get homeCompleteCommentPlaceholder => 'Add a comment (optional)';
+
+  @override
   String homeCompleteSuccess(String name) {
     return 'Marked \"$name\" as complete';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -245,7 +245,4 @@ class AppLocalizationsEn extends AppLocalizations {
   String appDetailTypeBadgeScheduled(int value, String unit) {
     return 'Every $value $unit';
   }
-
-  @override
-  String get appDetailCommentPlaceholder => 'Comment';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -244,7 +244,4 @@ class AppLocalizationsJa extends AppLocalizations {
   String appDetailTypeBadgeScheduled(int value, String unit) {
     return '定期 $value$unit';
   }
-
-  @override
-  String get appDetailCommentPlaceholder => 'コメント';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -54,6 +54,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get homeCompleteRecord => '完了を記録';
 
   @override
+  String get homeCompleteCommentPlaceholder => 'コメントを入力（任意）';
+
+  @override
   String homeCompleteSuccess(String name) {
     return '「$name」の完了を記録しました';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -244,4 +244,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String appDetailTypeBadgeScheduled(int value, String unit) {
     return '定期 $value$unit';
   }
+
+  @override
+  String get appDetailUpdateHistorySuccess => '履歴を更新しました';
 }

--- a/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
+++ b/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:dawnbreaker/data/model/task_history.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository_exception.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository_impl.dart';
@@ -37,6 +38,31 @@ class AppDetailViewModel extends _$AppDetailViewModel {
           },
         );
     ref.onDispose(subscription.cancel);
+  }
+
+  Future<void> updateExecution(
+    TaskHistory history, {
+    required DateTime executedAt,
+    String? comment,
+  }) async {
+    try {
+      await _repository.updateExecution(
+        history.id,
+        executedAt: executedAt,
+        comment: comment,
+      );
+    } on TaskRepositoryException {
+      if (!ref.mounted) return;
+      state = state.copyWith(
+        errorMessage: TaskUpdateErrorMessage(
+          handler: () => updateExecution(
+            history,
+            executedAt: executedAt,
+            comment: comment,
+          ),
+        ),
+      );
+    }
   }
 
   Future<void> deleteTask() async {

--- a/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
+++ b/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
@@ -51,6 +51,16 @@ class AppDetailViewModel extends _$AppDetailViewModel {
         executedAt: executedAt,
         comment: comment,
       );
+      if (!ref.mounted) return;
+      state = state.copyWith(
+        snackBarMessage: TaskExecutionUpdateSuccessSnackMessage(
+          handler: () => updateExecution(
+            history,
+            executedAt: history.executedAt,
+            comment: history.comment,
+          ),
+        ),
+      );
     } on TaskRepositoryException {
       if (!ref.mounted) return;
       state = state.copyWith(

--- a/lib/ui/app_detail/widgets/app_detail_screen.dart
+++ b/lib/ui/app_detail/widgets/app_detail_screen.dart
@@ -353,37 +353,9 @@ class _HistoryItem extends StatelessWidget {
   static const _lineWidth = 1.5;
   static const _paddingH = 20.0;
   static const _paddingV = 14.0;
-
-  // Container上端からの距離: paddingV + body行中心オフセット(4px)
-  static const _dotTopY = _paddingV + 4.0; // 18.0
-  static const _dotBottomY = _dotTopY + _dotSize; // 28.0
-  static const _lineLeft = _paddingH + _dotSize / 2 - _lineWidth / 2; // 24.25
-
-  BoxDecoration _containerDecoration(AppColorScheme colors) {
-    const radius = Radius.circular(AppRadius.lg);
-    final side = BorderSide(color: colors.border);
-    return switch ((isFirst, isLast)) {
-      (true, true) => BoxDecoration(
-        color: colors.surface,
-        borderRadius: const BorderRadius.all(radius),
-        border: Border.all(color: colors.border),
-      ),
-      (true, false) => BoxDecoration(
-        color: colors.surface,
-        borderRadius: const BorderRadius.vertical(top: radius),
-        border: Border(top: side, left: side, right: side),
-      ),
-      (false, true) => BoxDecoration(
-        color: colors.surface,
-        borderRadius: const BorderRadius.vertical(bottom: radius),
-        border: Border(bottom: side, left: side, right: side),
-      ),
-      _ => BoxDecoration(
-        color: colors.surface,
-        border: Border(left: side, right: side),
-      ),
-    };
-  }
+  static const _dotTopY = _paddingV + 4.0;
+  static const _dotBottomY = _dotTopY + _dotSize;
+  static const _lineLeft = _paddingH + _dotSize / 2 - _lineWidth / 2;
 
   BorderRadius? _borderRadius() {
     const radius = Radius.circular(AppRadius.lg);
@@ -392,6 +364,31 @@ class _HistoryItem extends StatelessWidget {
       (true, false) => const BorderRadius.vertical(top: radius),
       (false, true) => const BorderRadius.vertical(bottom: radius),
       _ => null,
+    };
+  }
+
+  BoxDecoration _containerDecoration(AppColorScheme colors) {
+    final side = BorderSide(color: colors.border);
+    return switch ((isFirst, isLast)) {
+      (true, true) => BoxDecoration(
+        color: colors.surface,
+        borderRadius: _borderRadius(),
+        border: Border.fromBorderSide(side),
+      ),
+      (true, false) => BoxDecoration(
+        color: colors.surface,
+        borderRadius: _borderRadius(),
+        border: Border(top: side, left: side, right: side),
+      ),
+      (false, true) => BoxDecoration(
+        color: colors.surface,
+        borderRadius: _borderRadius(),
+        border: Border(bottom: side, left: side, right: side),
+      ),
+      _ => BoxDecoration(
+        color: colors.surface,
+        border: Border(left: side, right: side),
+      ),
     };
   }
 

--- a/lib/ui/app_detail/widgets/app_detail_screen.dart
+++ b/lib/ui/app_detail/widgets/app_detail_screen.dart
@@ -14,6 +14,7 @@ import 'package:dawnbreaker/ui/common/components/app_icon_button.dart';
 import 'package:dawnbreaker/ui/common/components/app_section_header.dart';
 import 'package:dawnbreaker/ui/common/components/app_task_icon_tile.dart';
 import 'package:dawnbreaker/ui/common/messages_mixin.dart';
+import 'package:dawnbreaker/ui/home/widgets/task_complete_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -118,6 +119,7 @@ class _AppDetailScreenState extends ConsumerState<AppDetailScreen>
                     isLast: i == historyAndInterval.length - 1,
                     taskColor: task.color,
                     intervalDays: intervalDays,
+                    onTap: () => _showEditSheet(task, entry),
                   );
                 },
               ),
@@ -125,6 +127,22 @@ class _AppDetailScreenState extends ConsumerState<AppDetailScreen>
             SliverPadding(padding: EdgeInsets.only(bottom: 20 + bottomPadding)),
           ],
         ],
+      ),
+    );
+  }
+
+  void _showEditSheet(TaskItem task, TaskHistory entry) {
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (_) => TaskCompleteSheet(
+        task: task,
+        initialDate: entry.executedAt,
+        initialComment: entry.comment,
+        onConfirm: (date, comment) => ref
+            .read(appDetailViewModelProvider(taskId: widget.taskId).notifier)
+            .updateExecution(entry, executedAt: date, comment: comment),
       ),
     );
   }
@@ -321,6 +339,7 @@ class _HistoryItem extends StatelessWidget {
     required this.isLast,
     required this.taskColor,
     required this.intervalDays,
+    this.onTap,
   });
 
   final TaskHistory entry;
@@ -328,6 +347,7 @@ class _HistoryItem extends StatelessWidget {
   final bool isLast;
   final TaskColor taskColor;
   final int? intervalDays;
+  final VoidCallback? onTap;
 
   static const _dotSize = 10.0;
   static const _lineWidth = 1.5;
@@ -365,6 +385,16 @@ class _HistoryItem extends StatelessWidget {
     };
   }
 
+  BorderRadius? _borderRadius() {
+    const radius = Radius.circular(AppRadius.lg);
+    return switch ((isFirst, isLast)) {
+      (true, true) => const BorderRadius.all(radius),
+      (true, false) => const BorderRadius.vertical(top: radius),
+      (false, true) => const BorderRadius.vertical(bottom: radius),
+      _ => null,
+    };
+  }
+
   BoxDecoration _dotDecoration(Color dotColor, Color surface) => isFirst
       ? BoxDecoration(color: dotColor, shape: BoxShape.circle)
       : BoxDecoration(
@@ -378,9 +408,12 @@ class _HistoryItem extends StatelessWidget {
     final colors = context.appColorScheme;
     final dotColor = taskColor.baseColor(context);
 
-    return Container(
+    return Ink(
       decoration: _containerDecoration(colors),
-      child: Stack(
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: _borderRadius(),
+        child: Stack(
         children: [
           if (!isFirst || !isLast)
             Positioned(
@@ -440,6 +473,7 @@ class _HistoryItem extends StatelessWidget {
             ),
           ),
         ],
+      ),
       ),
     );
   }

--- a/lib/ui/app_detail/widgets/app_detail_screen.dart
+++ b/lib/ui/app_detail/widgets/app_detail_screen.dart
@@ -367,29 +367,20 @@ class _HistoryItem extends StatelessWidget {
     };
   }
 
+  Border _border(BorderSide side) => switch ((isFirst, isLast)) {
+    (true, true) => Border.fromBorderSide(side),
+    (true, false) => Border(top: side, left: side, right: side),
+    (false, true) => Border(bottom: side, left: side, right: side),
+    _ => Border(left: side, right: side),
+  };
+
   BoxDecoration _containerDecoration(AppColorScheme colors) {
     final side = BorderSide(color: colors.border);
-    return switch ((isFirst, isLast)) {
-      (true, true) => BoxDecoration(
-        color: colors.surface,
-        borderRadius: _borderRadius(),
-        border: Border.fromBorderSide(side),
-      ),
-      (true, false) => BoxDecoration(
-        color: colors.surface,
-        borderRadius: _borderRadius(),
-        border: Border(top: side, left: side, right: side),
-      ),
-      (false, true) => BoxDecoration(
-        color: colors.surface,
-        borderRadius: _borderRadius(),
-        border: Border(bottom: side, left: side, right: side),
-      ),
-      _ => BoxDecoration(
-        color: colors.surface,
-        border: Border(left: side, right: side),
-      ),
-    };
+    return BoxDecoration(
+      color: colors.surface,
+      borderRadius: _borderRadius(),
+      border: _border(side),
+    );
   }
 
   BoxDecoration _dotDecoration(Color dotColor, Color surface) => isFirst

--- a/lib/ui/app_detail/widgets/app_detail_screen.dart
+++ b/lib/ui/app_detail/widgets/app_detail_screen.dart
@@ -392,11 +392,11 @@ class _HistoryItem extends StatelessWidget {
               child: ColoredBox(color: colors.divider),
             ),
           Padding(
-            padding: const EdgeInsets.fromLTRB(
+            padding: EdgeInsets.fromLTRB(
               _paddingH,
               _paddingV,
               _paddingH,
-              _paddingV,
+              entry.comment == null ? _paddingV : 8,
             ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -422,17 +422,19 @@ class _HistoryItem extends StatelessWidget {
                     ),
                     if (intervalDays != null)
                       Text(
-                        context.l10n.appDetailDaysInterval(intervalDays!),
+                        intervalDays! == 0
+                            ? context.l10n.homeDueToday
+                            : context.l10n.appDetailDaysInterval(intervalDays!),
                         style: AppTextStyle.caption.copyWith(
                           color: colors.textMuted,
                         ),
                       ),
                   ],
                 ),
-                if (isFirst)
+                if (entry.comment case final comment?)
                   Padding(
                     padding: const EdgeInsets.only(top: 8, left: _dotSize + 12),
-                    child: _CommentPlaceholder(colors: colors),
+                    child: _HistoryComment(comment: comment, colors: colors),
                   ),
               ],
             ),
@@ -443,22 +445,25 @@ class _HistoryItem extends StatelessWidget {
   }
 }
 
-class _CommentPlaceholder extends StatelessWidget {
-  const _CommentPlaceholder({required this.colors});
+class _HistoryComment extends StatelessWidget {
+  const _HistoryComment({required this.comment, required this.colors});
 
+  final String comment;
   final AppColorScheme colors;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+    return DecoratedBox(
       decoration: BoxDecoration(
         border: Border.all(color: colors.border),
         borderRadius: BorderRadius.circular(AppRadius.md),
       ),
-      child: Text(
-        context.l10n.appDetailCommentPlaceholder,
-        style: AppTextStyle.caption.copyWith(color: colors.textSubtle),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: Text(
+          comment,
+          style: AppTextStyle.caption.copyWith(color: colors.textSubtle),
+        ),
       ),
     );
   }

--- a/lib/ui/common/messages_mixin.dart
+++ b/lib/ui/common/messages_mixin.dart
@@ -72,6 +72,8 @@ mixin MessagesListenMixin<T extends ConsumerStatefulWidget>
       ctx.l10n.editorSaveEditSuccess(taskName),
     TaskDeleteSuccessSnackMessage(:final taskName) =>
       ctx.l10n.appDetailDeleteSuccess(taskName),
+    TaskExecutionUpdateSuccessSnackMessage() =>
+      ctx.l10n.appDetailUpdateHistorySuccess,
   };
 
   String _snackActionLabel(BuildContext ctx, SnackBarMessage m) => switch (m) {
@@ -79,6 +81,7 @@ mixin MessagesListenMixin<T extends ConsumerStatefulWidget>
     TaskCreateSuccessSnackMessage() => ctx.l10n.undo,
     TaskUpdateSuccessSnackMessage() => ctx.l10n.undo,
     TaskDeleteSuccessSnackMessage() => ctx.l10n.undo,
+    TaskExecutionUpdateSuccessSnackMessage() => ctx.l10n.undo,
   };
 
   String _errorText(BuildContext ctx, ErrorMessage e) => switch (e) {

--- a/lib/ui/common/snack_bar_message.dart
+++ b/lib/ui/common/snack_bar_message.dart
@@ -26,3 +26,7 @@ class TaskDeleteSuccessSnackMessage extends SnackBarMessage {
   TaskDeleteSuccessSnackMessage({required this.taskName, super.handler});
   final String taskName;
 }
+
+class TaskExecutionUpdateSuccessSnackMessage extends SnackBarMessage {
+  TaskExecutionUpdateSuccessSnackMessage({super.handler});
+}

--- a/lib/ui/home/viewmodel/home_view_model.dart
+++ b/lib/ui/home/viewmodel/home_view_model.dart
@@ -37,11 +37,16 @@ class HomeViewModel extends _$HomeViewModel {
     state = state.copyWith(selectedFilter: filter);
   }
 
-  Future<void> recordCompletion(TaskItem task, DateTime executedAt) async {
+  Future<void> recordExecution(
+    TaskItem task,
+    DateTime executedAt,
+    String? comment,
+  ) async {
     try {
       final history = await _repository.recordExecution(
         task.id,
         executedAt: executedAt,
+        comment: comment,
       );
       if (!ref.mounted) return;
       state = state.copyWith(

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -101,9 +101,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
       isScrollControlled: true,
       builder: (_) => TaskCompleteSheet(
         task: task,
-        onConfirm: (date) => ref
+        onConfirm: (date, comment) => ref
             .read(homeViewModelProvider.notifier)
-            .recordCompletion(task, date),
+            .recordExecution(task, date, comment),
       ),
     );
   }

--- a/lib/ui/home/widgets/task_complete_sheet.dart
+++ b/lib/ui/home/widgets/task_complete_sheet.dart
@@ -15,18 +15,32 @@ class TaskCompleteSheet extends StatefulWidget {
     super.key,
     required this.task,
     required this.onConfirm,
+    this.initialDate,
+    this.initialComment,
   });
 
   final TaskItem task;
   final void Function(DateTime date, String? comment) onConfirm;
+  final DateTime? initialDate;
+  final String? initialComment;
 
   @override
   State<TaskCompleteSheet> createState() => _TaskCompleteSheetState();
 }
 
 class _TaskCompleteSheetState extends State<TaskCompleteSheet> {
-  DateTime _selectedDate = DateTime.now().truncateTime;
+  late DateTime _selectedDate;
   final _commentController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDate =
+        (widget.initialDate ?? DateTime.now()).truncateTime;
+    if (widget.initialComment case final comment?) {
+      _commentController.text = comment;
+    }
+  }
 
   @override
   void dispose() {
@@ -131,7 +145,9 @@ class _TaskCompleteSheetState extends State<TaskCompleteSheet> {
         Expanded(
           flex: 3,
           child: AppButton(
-            label: context.l10n.homeCompleteRecord,
+            label: widget.initialDate != null
+                ? context.l10n.editorSaveEdit
+                : context.l10n.homeCompleteRecord,
             size: AppButtonSize.large,
             fullWidth: true,
             onPressed: () {

--- a/lib/ui/home/widgets/task_complete_sheet.dart
+++ b/lib/ui/home/widgets/task_complete_sheet.dart
@@ -5,6 +5,7 @@ import 'package:dawnbreaker/core/context_extension.dart';
 import 'package:dawnbreaker/core/date_util.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/ui/common/components/app_button.dart';
+import 'package:dawnbreaker/ui/common/components/app_input.dart';
 import 'package:dawnbreaker/ui/common/components/app_task_icon_tile.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
@@ -17,7 +18,7 @@ class TaskCompleteSheet extends StatefulWidget {
   });
 
   final TaskItem task;
-  final void Function(DateTime date) onConfirm;
+  final void Function(DateTime date, String? comment) onConfirm;
 
   @override
   State<TaskCompleteSheet> createState() => _TaskCompleteSheetState();
@@ -25,23 +26,35 @@ class TaskCompleteSheet extends StatefulWidget {
 
 class _TaskCompleteSheetState extends State<TaskCompleteSheet> {
   DateTime _selectedDate = DateTime.now().truncateTime;
+  final _commentController = TextEditingController();
+
+  @override
+  void dispose() {
+    _commentController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final bottom = MediaQuery.paddingOf(context).bottom;
+    final safeBottom = MediaQuery.paddingOf(context).bottom;
+    final keyboardBottom = MediaQuery.viewInsetsOf(context).bottom;
 
-    return Padding(
-      padding: EdgeInsets.fromLTRB(20, 0, 20, 16 + bottom),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          _titleArea,
-          const SizedBox(height: 20),
-          _calendar,
-          const SizedBox(height: 16),
-          _buttonArea,
-        ],
+    return SingleChildScrollView(
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(20, 0, 20, 16 + safeBottom + keyboardBottom),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _titleArea,
+            const SizedBox(height: 20),
+            _calendar,
+            const SizedBox(height: 16),
+            _commentArea,
+            const SizedBox(height: 16),
+            _buttonArea,
+          ],
+        ),
       ),
     );
   }
@@ -96,6 +109,11 @@ class _TaskCompleteSheetState extends State<TaskCompleteSheet> {
     );
   }
 
+  Widget get _commentArea => AppTextInput(
+    controller: _commentController,
+    hintText: context.l10n.homeCompleteCommentPlaceholder,
+  );
+
   Widget get _buttonArea {
     return Row(
       children: [
@@ -118,7 +136,11 @@ class _TaskCompleteSheetState extends State<TaskCompleteSheet> {
             fullWidth: true,
             onPressed: () {
               Navigator.of(context).pop();
-              widget.onConfirm(_selectedDate);
+              final comment = _commentController.text.trim();
+              widget.onConfirm(
+                _selectedDate,
+                comment.isEmpty ? null : comment,
+              );
             },
           ),
         ),

--- a/test/data/model/task_item_test.dart
+++ b/test/data/model/task_item_test.dart
@@ -13,7 +13,7 @@ void main() {
 
     test('履歴が1件のとき null を返す', () {
       final task = _periodTask(
-        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1))],
+        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null)],
       );
       expect(task.scheduledAt, isNull);
     });
@@ -22,8 +22,8 @@ void main() {
       // 間隔: 31日 → 平均31日 → 2/1 + 31日 = 3/4
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1)),
-          TaskHistory(id: 2, executedAt: DateTime(2025, 2, 1)),
+          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: 2, executedAt: DateTime(2025, 2, 1), comment: null),
         ],
       );
       expect(task.scheduledAt, DateTime(2025, 3, 4));
@@ -33,9 +33,9 @@ void main() {
       // 間隔: 10日, 20日 → 平均15日 → 1/31 + 15日 = 2/15
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1)),
-          TaskHistory(id: 2, executedAt: DateTime(2025, 1, 11)),
-          TaskHistory(id: 3, executedAt: DateTime(2025, 1, 31)),
+          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: 2, executedAt: DateTime(2025, 1, 11), comment: null),
+          TaskHistory(id: 3, executedAt: DateTime(2025, 1, 31), comment: null),
         ],
       );
       expect(task.scheduledAt, DateTime(2025, 2, 15));
@@ -55,7 +55,7 @@ void main() {
       final task = _scheduledTask(
         scheduleValue: 14,
         scheduleUnit: ScheduleUnit.day,
-        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1))],
+        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null)],
       );
       expect(task.scheduledAt, DateTime(2025, 1, 15));
     });
@@ -64,7 +64,7 @@ void main() {
       final task = _scheduledTask(
         scheduleValue: 2,
         scheduleUnit: ScheduleUnit.week,
-        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1))],
+        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null)],
       );
       expect(task.scheduledAt, DateTime(2025, 1, 15));
     });
@@ -73,7 +73,7 @@ void main() {
       final task = _scheduledTask(
         scheduleValue: 3,
         scheduleUnit: ScheduleUnit.month,
-        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 10))],
+        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 10), comment: null)],
       );
       expect(task.scheduledAt, DateTime(2025, 4, 10));
     });
@@ -82,7 +82,7 @@ void main() {
   group('PeriodTaskItem.executionIntervalDays', () {
     test('履歴が1件のとき空リストを返す', () {
       final task = _periodTask(
-        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1))],
+        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null)],
       );
       expect(task.executionIntervalDays, isEmpty);
     });
@@ -90,8 +90,8 @@ void main() {
     test('深夜0時の履歴: 1/1→2/1 は31日', () {
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1)),
-          TaskHistory(id: 2, executedAt: DateTime(2025, 2, 1)),
+          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: 2, executedAt: DateTime(2025, 2, 1), comment: null),
         ],
       );
       expect(task.executionIntervalDays, [31]);
@@ -100,8 +100,8 @@ void main() {
     test('夜遅い実行→翌朝実行でも1日としてカウントされる（22:00→翌08:00）', () {
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1, 22, 0)),
-          TaskHistory(id: 2, executedAt: DateTime(2025, 1, 2, 8, 0)),
+          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1, 22, 0), comment: null),
+          TaskHistory(id: 2, executedAt: DateTime(2025, 1, 2, 8, 0), comment: null),
         ],
       );
       expect(task.executionIntervalDays, [1]);
@@ -112,9 +112,9 @@ void main() {
       // カレンダー日数: 31日, 31日
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1, 14, 0)),
-          TaskHistory(id: 2, executedAt: DateTime(2025, 2, 1, 8, 0)),
-          TaskHistory(id: 3, executedAt: DateTime(2025, 3, 4, 22, 0)),
+          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1, 14, 0), comment: null),
+          TaskHistory(id: 2, executedAt: DateTime(2025, 2, 1, 8, 0), comment: null),
+          TaskHistory(id: 3, executedAt: DateTime(2025, 3, 4, 22, 0), comment: null),
         ],
       );
       expect(task.executionIntervalDays, [31, 31]);
@@ -132,7 +132,7 @@ void main() {
     test('scheduledAt が null のとき NoDueDate を返す', () {
       // PeriodTask で履歴1件 → scheduledAt が null
       final task = _periodTask(
-        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1))],
+        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null)],
       );
       expect(task.computeProgress(DateTime(2025, 2, 1)), isA<NoDueDate>());
     });
@@ -141,8 +141,8 @@ void main() {
       // lastExecutedAt=1/1, scheduledAt=3/4(+62日), now=2/1(+31日) → progress=0.5
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1)),
-          TaskHistory(id: 2, executedAt: DateTime(2025, 3, 4)),
+          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: 2, executedAt: DateTime(2025, 3, 4), comment: null),
         ],
       );
       // scheduledAt = 3/4 + 62日 = 5/5
@@ -157,7 +157,7 @@ void main() {
       final task = _scheduledTask(
         scheduleValue: 30,
         scheduleUnit: ScheduleUnit.day,
-        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1))],
+        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null)],
       );
       // scheduledAt = 1/31, now = 2/15 → 超過
       final progress = task.computeProgress(DateTime(2025, 2, 15));
@@ -172,7 +172,7 @@ void main() {
       final task = _scheduledTask(
         scheduleValue: 0,
         scheduleUnit: ScheduleUnit.day,
-        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1))],
+        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null)],
       );
       final progress = task.computeProgress(DateTime(2025, 1, 1));
       expect(progress, isA<DueDate>());
@@ -185,7 +185,7 @@ void main() {
         final task = _scheduledTask(
           scheduleValue: 1,
           scheduleUnit: ScheduleUnit.day,
-          taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2026, 4, 23))],
+          taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2026, 4, 23), comment: null)],
         );
         final p = task.computeProgress(DateTime(2026, 4, 24, 14, 0)) as DueDate;
         expect(p.isToday, true);
@@ -196,7 +196,7 @@ void main() {
         final task = _scheduledTask(
           scheduleValue: 1,
           scheduleUnit: ScheduleUnit.day,
-          taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2026, 4, 24))],
+          taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2026, 4, 24), comment: null)],
         );
         final p = task.computeProgress(DateTime(2026, 4, 24, 14, 0)) as DueDate;
         expect(p.isToday, false);
@@ -212,7 +212,7 @@ void main() {
           scheduleValue: 30,
           scheduleUnit: ScheduleUnit.day,
           taskHistory: [
-            TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1, 14, 0)),
+            TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1, 14, 0), comment: null),
           ],
         );
         final p = task.computeProgress(DateTime(2025, 1, 16)) as DueDate;
@@ -226,7 +226,7 @@ void main() {
       TaskItem task30() => _scheduledTask(
         scheduleValue: 30,
         scheduleUnit: ScheduleUnit.day,
-        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1))],
+        taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null)],
       );
 
       test('scheduledAt の前日: isOverdue=false, daysRemaining=1', () {

--- a/test/data/repository/task/task_repository_test.dart
+++ b/test/data/repository/task/task_repository_test.dart
@@ -364,6 +364,76 @@ void main() {
       final tasks = await repository.allTaskItems().first;
       expect(tasks.first.scheduledAt, isNotNull);
     });
+
+    test('コメントなしで記録すると戻り値の comment は null になる', () async {
+      final id = await repository.addTask(
+        taskType: TaskType.period,
+        name: '散髪',
+        icon: '📝',
+        color: TaskColor.none,
+        executedAt: DateTime(2025, 1, 1),
+      );
+      final history = await repository.recordExecution(
+        id,
+        executedAt: DateTime(2025, 6, 1),
+      );
+
+      expect(history.comment, isNull);
+    });
+
+    test('コメントなしで記録した履歴を取得すると comment は null になる', () async {
+      final id = await repository.addTask(
+        taskType: TaskType.period,
+        name: '散髪',
+        icon: '📝',
+        color: TaskColor.none,
+        executedAt: DateTime(2025, 1, 1),
+      );
+      final history = await repository.recordExecution(
+        id,
+        executedAt: DateTime(2025, 6, 1),
+      );
+
+      final task = await repository.findTaskById(id);
+      final recorded = task.taskHistory.firstWhere((h) => h.id == history.id);
+      expect(recorded.comment, isNull);
+    });
+
+    test('コメントありで記録すると戻り値の comment が保存される', () async {
+      final id = await repository.addTask(
+        taskType: TaskType.period,
+        name: '散髪',
+        icon: '📝',
+        color: TaskColor.none,
+        executedAt: DateTime(2025, 1, 1),
+      );
+      final history = await repository.recordExecution(
+        id,
+        executedAt: DateTime(2025, 6, 1),
+        comment: '良い感じ',
+      );
+
+      expect(history.comment, '良い感じ');
+    });
+
+    test('コメントありで記録した履歴を取得すると comment が保持されている', () async {
+      final id = await repository.addTask(
+        taskType: TaskType.period,
+        name: '散髪',
+        icon: '📝',
+        color: TaskColor.none,
+        executedAt: DateTime(2025, 1, 1),
+      );
+      final history = await repository.recordExecution(
+        id,
+        executedAt: DateTime(2025, 6, 1),
+        comment: '良い感じ',
+      );
+
+      final task = await repository.findTaskById(id);
+      final recorded = task.taskHistory.firstWhere((h) => h.id == history.id);
+      expect(recorded.comment, '良い感じ');
+    });
   });
 
   group('updateTask', () {

--- a/test/data/repository/task/task_repository_test.dart
+++ b/test/data/repository/task/task_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:dawnbreaker/data/database/app_database.dart';
 import 'package:dawnbreaker/data/model/schedule_unit.dart';
 import 'package:dawnbreaker/data/model/task_color.dart';
+import 'package:dawnbreaker/data/model/task_history.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/data/model/task_type.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository.dart';
@@ -88,6 +89,13 @@ void main() {
       await expectLater(
         () => closedRepo.recordExecution(1, executedAt: DateTime.now()),
         throwsA(isA<TaskSaveException>()),
+      );
+    });
+
+    test('updateExecution: TaskUpdateException を投げる', () async {
+      await expectLater(
+        () => closedRepo.updateExecution(1, executedAt: DateTime.now()),
+        throwsA(isA<TaskUpdateException>()),
       );
     });
 
@@ -433,6 +441,80 @@ void main() {
       final task = await repository.findTaskById(id);
       final recorded = task.taskHistory.firstWhere((h) => h.id == history.id);
       expect(recorded.comment, '良い感じ');
+    });
+  });
+
+  group('updateExecution', () {
+    Future<({int taskId, TaskHistory history})> _setup({
+      DateTime? executedAt,
+      String? comment,
+    }) async {
+      final id = await repository.addTask(
+        taskType: TaskType.period,
+        name: '散髪',
+        icon: '📝',
+        color: TaskColor.none,
+        executedAt: DateTime(2025, 1, 1),
+      );
+      final history = await repository.recordExecution(
+        id,
+        executedAt: executedAt ?? DateTime(2025, 6, 1),
+        comment: comment,
+      );
+      return (taskId: id, history: history);
+    }
+
+    test('日付を更新できる', () async {
+      final (:taskId, :history) = await _setup();
+      await repository.updateExecution(
+        history.id,
+        executedAt: DateTime(2025, 7, 1),
+      );
+
+      final task = await repository.findTaskById(taskId);
+      final updated = task.taskHistory.firstWhere((h) => h.id == history.id);
+      expect(updated.executedAt, DateTime(2025, 7, 1));
+    });
+
+    test('コメントを追加できる（null → 文字列）', () async {
+      final (:taskId, :history) = await _setup();
+      await repository.updateExecution(
+        history.id,
+        executedAt: history.executedAt,
+        comment: '更新コメント',
+      );
+
+      final task = await repository.findTaskById(taskId);
+      final updated = task.taskHistory.firstWhere((h) => h.id == history.id);
+      expect(updated.comment, '更新コメント');
+    });
+
+    test('コメントを削除できる（文字列 → null）', () async {
+      final (:taskId, :history) = await _setup(comment: '元のコメント');
+      await repository.updateExecution(
+        history.id,
+        executedAt: history.executedAt,
+      );
+
+      final task = await repository.findTaskById(taskId);
+      final updated = task.taskHistory.firstWhere((h) => h.id == history.id);
+      expect(updated.comment, isNull);
+    });
+
+    test('他の履歴には影響しない', () async {
+      final (:taskId, :history) = await _setup();
+      final other = await repository.recordExecution(
+        taskId,
+        executedAt: DateTime(2025, 9, 1),
+      );
+      await repository.updateExecution(
+        history.id,
+        executedAt: DateTime(2025, 7, 1),
+      );
+
+      final task = await repository.findTaskById(taskId);
+      final otherUpdated = task.taskHistory.firstWhere((h) => h.id == other.id);
+      expect(otherUpdated.executedAt, DateTime(2025, 9, 1));
     });
   });
 

--- a/test/helpers/fake_task_repository.dart
+++ b/test/helpers/fake_task_repository.dart
@@ -100,6 +100,8 @@ class FakeTaskRepository implements TaskRepository {
     _notify();
   }
 
+  String? lastRecordedComment;
+
   @override
   Future<TaskHistory> recordExecution(
     int taskId, {
@@ -107,6 +109,7 @@ class FakeTaskRepository implements TaskRepository {
     String? comment,
   }) async {
     if (shouldThrow) throw const TaskSaveException('テストエラー');
+    lastRecordedComment = comment;
     return TaskHistory(id: _nextId++, executedAt: executedAt, comment: comment);
   }
 

--- a/test/helpers/fake_task_repository.dart
+++ b/test/helpers/fake_task_repository.dart
@@ -104,9 +104,10 @@ class FakeTaskRepository implements TaskRepository {
   Future<TaskHistory> recordExecution(
     int taskId, {
     required DateTime executedAt,
+    String? comment,
   }) async {
     if (shouldThrow) throw const TaskSaveException('テストエラー');
-    return TaskHistory(id: _nextId++, executedAt: executedAt);
+    return TaskHistory(id: _nextId++, executedAt: executedAt, comment: comment);
   }
 
   @override

--- a/test/helpers/fake_task_repository.dart
+++ b/test/helpers/fake_task_repository.dart
@@ -114,6 +114,15 @@ class FakeTaskRepository implements TaskRepository {
   }
 
   @override
+  Future<void> updateExecution(
+    int executionId, {
+    required DateTime executedAt,
+    String? comment,
+  }) async {
+    if (shouldThrow) throw const TaskUpdateException('テストエラー');
+  }
+
+  @override
   Future<void> deleteExecution(int executionId) async {
     if (shouldThrow) throw const TaskDeleteException('テストエラー');
   }

--- a/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
+++ b/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
@@ -370,7 +370,7 @@ final _taskOneHistory = TaskItem.period(
   furigana: 'たすく',
   icon: '📝',
   color: TaskColor.blue,
-  taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1))],
+  taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1), comment: null)],
 );
 
 final _taskMultiHistory = TaskItem.period(
@@ -380,9 +380,9 @@ final _taskMultiHistory = TaskItem.period(
   icon: '📝',
   color: TaskColor.green,
   taskHistory: [
-    TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1)),
-    TaskHistory(id: 2, executedAt: DateTime(2026, 2, 1)),
-    TaskHistory(id: 3, executedAt: DateTime(2026, 3, 4)),
+    TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1), comment: null),
+    TaskHistory(id: 2, executedAt: DateTime(2026, 2, 1), comment: null),
+    TaskHistory(id: 3, executedAt: DateTime(2026, 3, 4), comment: null),
   ],
 );
 

--- a/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
+++ b/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
@@ -273,6 +273,46 @@ void main() {
           isNull,
         );
       });
+
+      test('成功時に TaskExecutionUpdateSuccessSnackMessage がセットされる', () async {
+        await container
+            .read(appDetailViewModelProvider(taskId: _taskOneHistory.id).notifier)
+            .updateExecution(
+              _taskOneHistory.taskHistory.first,
+              executedAt: DateTime(2026, 2, 1),
+            );
+        expect(
+          container
+              .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+              .snackBarMessage,
+          isA<TaskExecutionUpdateSuccessSnackMessage>(),
+        );
+      });
+
+      test('snackBarMessage の handler を呼び出すと元の日時・コメントで再更新される', () async {
+        final original = _taskOneHistory.taskHistory.first;
+        await container
+            .read(appDetailViewModelProvider(taskId: _taskOneHistory.id).notifier)
+            .updateExecution(
+              original,
+              executedAt: DateTime(2026, 2, 1),
+              comment: '変更後',
+            );
+
+        final handler = container
+            .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+            .snackBarMessage
+            ?.handler;
+        expect(handler, isNotNull);
+        await handler!();
+
+        expect(
+          container
+              .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+              .errorMessage,
+          isNull,
+        );
+      });
     });
 
     group('履歴の更新 失敗時', () {

--- a/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
+++ b/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
@@ -237,6 +237,90 @@ void main() {
       });
     });
 
+    group('履歴の更新 成功時', () {
+      setUp(() async {
+        setUpContainer();
+        await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+      });
+
+      test('成功時はエラーなし', () async {
+        await container
+            .read(appDetailViewModelProvider(taskId: _taskOneHistory.id).notifier)
+            .updateExecution(
+              _taskOneHistory.taskHistory.first,
+              executedAt: DateTime(2026, 2, 1),
+            );
+        expect(
+          container
+              .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+              .errorMessage,
+          isNull,
+        );
+      });
+
+      test('コメントありで更新してもエラーなし', () async {
+        await container
+            .read(appDetailViewModelProvider(taskId: _taskOneHistory.id).notifier)
+            .updateExecution(
+              _taskOneHistory.taskHistory.first,
+              executedAt: DateTime(2026, 2, 1),
+              comment: '更新コメント',
+            );
+        expect(
+          container
+              .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+              .errorMessage,
+          isNull,
+        );
+      });
+    });
+
+    group('履歴の更新 失敗時', () {
+      setUp(() async {
+        fakeRepository = FakeTaskRepository(
+          initialTasks: _testTasks,
+          shouldThrow: true,
+        );
+        container = ProviderContainer(
+          overrides: [
+            taskRepositoryProvider.overrideWith((_) => fakeRepository),
+          ],
+        );
+        await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+      });
+
+      test('失敗時に TaskUpdateErrorMessage がセットされる', () async {
+        await container
+            .read(appDetailViewModelProvider(taskId: _taskOneHistory.id).notifier)
+            .updateExecution(
+              _taskOneHistory.taskHistory.first,
+              executedAt: DateTime(2026, 2, 1),
+            );
+        expect(
+          container
+              .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+              .errorMessage,
+          isA<TaskUpdateErrorMessage>(),
+        );
+      });
+
+      test('失敗時の errorMessage に retry handler がある', () async {
+        await container
+            .read(appDetailViewModelProvider(taskId: _taskOneHistory.id).notifier)
+            .updateExecution(
+              _taskOneHistory.taskHistory.first,
+              executedAt: DateTime(2026, 2, 1),
+            );
+        expect(
+          container
+              .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+              .errorMessage
+              ?.handler,
+          isNotNull,
+        );
+      });
+    });
+
     group('タスクの削除 成功時', () {
       setUp(() async {
         setUpContainer();

--- a/test/ui/editor/viewmodel/editor_view_model_test.dart
+++ b/test/ui/editor/viewmodel/editor_view_model_test.dart
@@ -270,7 +270,7 @@ final _testTasks = [
     furigana: 'はぶらしこうかん',
     icon: '🪥',
     color: TaskColor.blue,
-    taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1))],
+    taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1), comment: null)],
   ),
   TaskItem.scheduled(
     id: 2,
@@ -280,7 +280,7 @@ final _testTasks = [
     color: TaskColor.orange,
     scheduleValue: 2,
     scheduleUnit: ScheduleUnit.week,
-    taskHistory: [TaskHistory(id: 2, executedAt: DateTime(2026, 1, 1))],
+    taskHistory: [TaskHistory(id: 2, executedAt: DateTime(2026, 1, 1), comment: null)],
   ),
 ];
 

--- a/test/ui/home/viewmodel/home_task_list_test.dart
+++ b/test/ui/home/viewmodel/home_task_list_test.dart
@@ -23,7 +23,7 @@ void main() {
     color: TaskColor.none,
     scheduleValue: intervalDays,
     scheduleUnit: ScheduleUnit.day,
-    taskHistory: [TaskHistory(id: id, executedAt: lastExecutedAt)],
+    taskHistory: [TaskHistory(id: id, executedAt: lastExecutedAt, comment: null)],
   );
 
   // 超過: 10日前が最後、5日周期 → scheduledAt は5日前

--- a/test/ui/home/viewmodel/home_view_model_test.dart
+++ b/test/ui/home/viewmodel/home_view_model_test.dart
@@ -148,7 +148,7 @@ void main() {
       test('成功時はエラーなし', () async {
         await container
             .read(homeViewModelProvider.notifier)
-            .recordCompletion(_testTasks[0], DateTime(2026, 4, 1));
+            .recordExecution(_testTasks[0], DateTime(2026, 4, 1), null);
 
         expect(container.read(homeViewModelProvider).errorMessage, isNull);
       });
@@ -156,7 +156,7 @@ void main() {
       test('成功時に TaskCompleteSuccessSnackMessage がセットされる', () async {
         await container
             .read(homeViewModelProvider.notifier)
-            .recordCompletion(_testTasks[0], DateTime(2026, 4, 1));
+            .recordExecution(_testTasks[0], DateTime(2026, 4, 1), null);
 
         final msg = container.read(homeViewModelProvider).snackBarMessage;
         expect(msg, isA<TaskCompleteSuccessSnackMessage>());
@@ -169,7 +169,7 @@ void main() {
       test('成功時の snackBarMessage に undo ハンドラがある', () async {
         await container
             .read(homeViewModelProvider.notifier)
-            .recordCompletion(_testTasks[0], DateTime(2026, 4, 1));
+            .recordExecution(_testTasks[0], DateTime(2026, 4, 1), null);
 
         final msg = container.read(homeViewModelProvider).snackBarMessage;
         expect(msg?.handler, isNotNull);
@@ -190,7 +190,7 @@ void main() {
 
         await c
             .read(homeViewModelProvider.notifier)
-            .recordCompletion(_testTasks[0], DateTime(2026, 4, 1));
+            .recordExecution(_testTasks[0], DateTime(2026, 4, 1), null);
 
         expect(c.read(homeViewModelProvider).errorMessage, isNotNull);
       });
@@ -198,7 +198,7 @@ void main() {
       test('成功時の handler を呼び出してもエラーが発生しない', () async {
         await container
             .read(homeViewModelProvider.notifier)
-            .recordCompletion(_testTasks[0], DateTime(2026, 4, 1));
+            .recordExecution(_testTasks[0], DateTime(2026, 4, 1), null);
 
         final handler =
             container.read(homeViewModelProvider).snackBarMessage?.handler;
@@ -207,6 +207,35 @@ void main() {
         await handler!();
 
         expect(container.read(homeViewModelProvider).errorMessage, isNull);
+      });
+
+      group('コメントのバリエーション', () {
+        test('コメントなし(null)はリポジトリに null が渡される', () async {
+          await container
+              .read(homeViewModelProvider.notifier)
+              .recordExecution(_testTasks[0], DateTime(2026, 4, 1), null);
+
+          expect(fakeRepository.lastRecordedComment, isNull);
+        });
+
+        test('コメントあり: リポジトリに文字列が渡される', () async {
+          await container
+              .read(homeViewModelProvider.notifier)
+              .recordExecution(_testTasks[0], DateTime(2026, 4, 1), '良い感じ');
+
+          expect(fakeRepository.lastRecordedComment, '良い感じ');
+        });
+
+        test('コメントありでも成功時の snackBarMessage はセットされる', () async {
+          await container
+              .read(homeViewModelProvider.notifier)
+              .recordExecution(_testTasks[0], DateTime(2026, 4, 1), '良い感じ');
+
+          expect(
+            container.read(homeViewModelProvider).snackBarMessage,
+            isA<TaskCompleteSuccessSnackMessage>(),
+          );
+        });
       });
     });
 

--- a/test/ui/home/viewmodel/home_view_model_test.dart
+++ b/test/ui/home/viewmodel/home_view_model_test.dart
@@ -222,22 +222,22 @@ void main() {
         TaskItem.scheduled(
           id: 10, name: '超過', furigana: '', icon: '📝', color: TaskColor.none,
           scheduleValue: 5, scheduleUnit: ScheduleUnit.day,
-          taskHistory: [TaskHistory(id: 10, executedAt: now.subtract(const Duration(days: 10)))],
+          taskHistory: [TaskHistory(id: 10, executedAt: now.subtract(const Duration(days: 10)), comment: null)],
         ),
         TaskItem.scheduled(
           id: 11, name: '今日', furigana: '', icon: '📝', color: TaskColor.none,
           scheduleValue: 7, scheduleUnit: ScheduleUnit.day,
-          taskHistory: [TaskHistory(id: 11, executedAt: now.subtract(const Duration(days: 7)))],
+          taskHistory: [TaskHistory(id: 11, executedAt: now.subtract(const Duration(days: 7)), comment: null)],
         ),
         TaskItem.scheduled(
           id: 12, name: '今週', furigana: '', icon: '📝', color: TaskColor.none,
           scheduleValue: 7, scheduleUnit: ScheduleUnit.day,
-          taskHistory: [TaskHistory(id: 12, executedAt: now.subtract(const Duration(days: 4)))],
+          taskHistory: [TaskHistory(id: 12, executedAt: now.subtract(const Duration(days: 4)), comment: null)],
         ),
         TaskItem.scheduled(
           id: 13, name: '将来', furigana: '', icon: '📝', color: TaskColor.none,
           scheduleValue: 14, scheduleUnit: ScheduleUnit.day,
-          taskHistory: [TaskHistory(id: 13, executedAt: now)],
+          taskHistory: [TaskHistory(id: 13, executedAt: now, comment: null)],
         ),
         const TaskItem.period(
           id: 14, name: '不定期', furigana: '', icon: '📝',
@@ -294,7 +294,7 @@ final _testTasks = [
     furigana: 'はぶらしこうかん',
     icon: '📝',
     color: TaskColor.blue,
-    taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1))],
+    taskHistory: [TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1), comment: null)],
   ),
   TaskItem.period(
     id: 2,
@@ -302,7 +302,7 @@ final _testTasks = [
     furigana: 'さんぱつ',
     icon: '📝',
     color: TaskColor.none,
-    taskHistory: [TaskHistory(id: 2, executedAt: DateTime(2026, 1, 1))],
+    taskHistory: [TaskHistory(id: 2, executedAt: DateTime(2026, 1, 1), comment: null)],
   ),
 ];
 


### PR DESCRIPTION
## Summary

- `TaskHistory` にコメント列を追加し、DB・Repository・UI まで一貫して対応
- 完了記録シートにコメント入力欄を追加（キーボード対応済み）
- タスク詳細画面の履歴一覧でコメントを表示・編集可能に（タップで編集シート表示）
- 履歴更新成功時に「履歴を更新しました」スナックバーを表示（元に戻す付き）
- `restoreTask` でコメントが復元されないバグを修正

## Test plan

- [x] `fvm flutter test` が全テストパス（156件）
- [x] 完了記録シートでコメントを入力して記録できる
- [x] コメントなしで記録した場合、コメント欄が表示されない
- [x] タスク詳細の履歴をタップするとコメント付きで編集シートが開く
- [x] 編集後に「履歴を更新しました」スナックバーが表示される
- [x] 「元に戻す」タップで日時・コメントが元に戻る
- [x] タスク削除 → 「元に戻す」でコメントも含めて復元される

🤖 Generated with [Claude Code](https://claude.com/claude-code)