### PR TITLE
当たり判定を拡張するコンポーネントを追加

### DIFF
--- a/lib/ui/app_detail/widgets/app_detail_screen.dart
+++ b/lib/ui/app_detail/widgets/app_detail_screen.dart
@@ -73,7 +73,6 @@ class _AppDetailScreenState extends ConsumerState<AppDetailScreen>
                       label: context.l10n.appDetailEdit,
                       onTap: () => context.push('/editor', extra: task.id),
                     ),
-                    const SizedBox(width: 4),
                     AppIconButton(
                       icon: Icons.delete,
                       tone: AppIconTone.destruction,

--- a/lib/ui/common/components/app_icon_button.dart
+++ b/lib/ui/common/components/app_icon_button.dart
@@ -1,6 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:dawnbreaker/ui/common/extend_hit_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -25,22 +26,20 @@ class AppIconButton extends StatelessWidget {
     final colors = context.appColorScheme;
     final borderRadius = BorderRadius.circular(AppRadius.md);
 
-    return InkWell(
-      onTap: onTap,
-      borderRadius: borderRadius,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
-        child: Center(
-          child: Ink(
-            height: 36,
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            decoration: BoxDecoration(
-              color: colors.appIconBackGroundColor(tone),
-              border: Border.all(color: colors.appIconBorderColor(tone)),
-              borderRadius: borderRadius,
-            ),
-            child: Center(widthFactor: 1.0, child: _buttonContent(colors)),
+    return ExpandHitTest(
+      expandArea: const EdgeInsets.all(6),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: borderRadius,
+        child: Ink(
+          height: 36,
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          decoration: BoxDecoration(
+            color: colors.appIconBackGroundColor(tone),
+            border: Border.all(color: colors.appIconBorderColor(tone)),
+            borderRadius: borderRadius,
           ),
+          child: Center(widthFactor: 1.0, child: _buttonContent(colors)),
         ),
       ),
     );

--- a/lib/ui/common/extend_hit_test.dart
+++ b/lib/ui/common/extend_hit_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+class ExpandHitTest extends StatelessWidget {
+  const ExpandHitTest({
+    super.key,
+    required this.expandArea,
+    required this.child,
+  });
+
+  final EdgeInsets expandArea;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: expandArea,
+      child: _ExpandHitTestCore(expandArea: expandArea, child: child),
+    );
+  }
+}
+
+class _ExpandHitTestCore extends SingleChildRenderObjectWidget {
+  const _ExpandHitTestCore({required this.expandArea, required super.child});
+
+  final EdgeInsets expandArea;
+
+  @override
+  _ExpandHitTestRenderBox createRenderObject(BuildContext context) =>
+      _ExpandHitTestRenderBox(expandArea: expandArea);
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    covariant _ExpandHitTestRenderBox renderObject,
+  ) {
+    renderObject.expandArea = expandArea;
+  }
+}
+
+class _ExpandHitTestRenderBox extends RenderProxyBox {
+  _ExpandHitTestRenderBox({required this.expandArea});
+
+  EdgeInsets expandArea;
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    final expandedRect = expandArea.inflateRect(Offset.zero & size);
+    if (!expandedRect.contains(position)) {
+      return false;
+    }
+    final clampedPosition = Offset(
+      position.dx.clamp(0.0, size.width),
+      position.dy.clamp(0.0, size.height),
+    );
+    return hitTestChildren(result, position: clampedPosition) ||
+        hitTestSelf(clampedPosition);
+  }
+}


### PR DESCRIPTION
## 概要

- アイコンボタンがガイドラインより小さいので、当たり判定を単純に広げたため、押したときのrippleをボタン外部にも表示されていた

## 対応

- hitTestで当たり判定を拡張するコンポーネントを追加

## やってないこと

- `BoxHitTestEntry` の追加
    - 複雑なジェスチャに対応させる必要がある場合にはやったほうがよさそうですが今回はないので
- `Padding` を使わず描画処理を内部で行う