### PR TITLE
タスクカラーをリストアイテムとボタンに反映

### DIFF
--- a/lib/ui/common/components/app_pill_button.dart
+++ b/lib/ui/common/components/app_pill_button.dart
@@ -1,5 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:dawnbreaker/data/model/task_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -12,20 +13,26 @@ class AppPillButton extends StatelessWidget {
     this.onPressed,
     this.variant = AppPillButtonVariant.primary,
     this.leading,
+    this.tintColor,
   });
 
   final String label;
   final VoidCallback? onPressed;
   final AppPillButtonVariant variant;
   final Widget? leading;
+  final TaskColor? tintColor;
 
   @override
   Widget build(BuildContext context) {
     final c = context.appColorScheme;
 
     final (bg, fg) = switch (variant) {
-      AppPillButtonVariant.primary => (c.primary, c.primaryOn),
-      AppPillButtonVariant.secondary => (c.surface, c.text),
+      .primary when tintColor is TaskColor => (
+        tintColor!.softColor(context),
+        tintColor!.onColor(context),
+      ),
+      .primary => (c.primary, c.primaryOn),
+      .secondary => (c.surface, c.text),
     };
 
     final style = ElevatedButton.styleFrom(

--- a/lib/ui/common/components/app_task_list_item.dart
+++ b/lib/ui/common/components/app_task_list_item.dart
@@ -1,5 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/core/context_extension.dart';
+import 'package:dawnbreaker/core/date_util.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/data/model/task_progress.dart';
 import 'package:dawnbreaker/ui/common/components/app_badge.dart';
@@ -7,7 +8,6 @@ import 'package:dawnbreaker/ui/common/components/app_pill_button.dart';
 import 'package:dawnbreaker/ui/common/components/app_progress_bar.dart';
 import 'package:dawnbreaker/ui/common/components/app_task_icon_tile.dart';
 import 'package:flutter/material.dart';
-import 'package:dawnbreaker/core/date_util.dart';
 
 class AppTaskListItem extends StatelessWidget {
   const AppTaskListItem({
@@ -34,60 +34,67 @@ class AppTaskListItem extends StatelessWidget {
             Container(width: 4, color: task.color.baseColor(context)),
             Expanded(
               child: InkWell(
+                highlightColor: task.color
+                    .softColor(context)
+                    .withValues(alpha: 0.2),
+                splashColor: task.color.softColor(context),
                 onTap: onTap,
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(14, 10, 12, 10),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      AppTaskIconTile(
-                        emoji: task.icon,
-                        color: task.color,
-                        size: 32,
-                      ),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              task.name,
-                              style: TextStyle(
-                                fontSize: 14,
-                                fontWeight: FontWeight.w600,
-                                color: colors.text,
-                                letterSpacing: -0.2,
+                child: Ink(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(14, 10, 12, 10),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        AppTaskIconTile(
+                          emoji: task.icon,
+                          color: task.color,
+                          size: 32,
+                        ),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                task.name,
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                  color: colors.text,
+                                  letterSpacing: -0.2,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
                               ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            if (taskProgress is DueDate) ...[
-                              const SizedBox(height: 4),
-                              _DateRow(
-                                taskProgress: taskProgress,
-                                colors: colors,
-                              ),
-                              const SizedBox(height: 6),
-                              AppProgressBar(
-                                value: taskProgress.progress,
-                                isOverdue: taskProgress.isOverdue,
-                                thickness: 2,
-                              ),
+                              if (taskProgress is DueDate) ...[
+                                const SizedBox(height: 4),
+                                _DateRow(
+                                  taskProgress: taskProgress,
+                                  colors: colors,
+                                ),
+                                const SizedBox(height: 6),
+                                AppProgressBar(
+                                  value: taskProgress.progress,
+                                  isOverdue: taskProgress.isOverdue,
+                                  thickness: 2,
+                                ),
+                              ],
                             ],
-                          ],
+                          ),
                         ),
-                      ),
-                      const SizedBox(width: 12),
-                      AppPillButton(
-                        label: context.l10n.homeComplete,
-                        onPressed: onComplete,
-                        leading: const Icon(
-                          Icons.check,
-                          fontWeight: FontWeight.w700,
+                        const SizedBox(width: 12),
+                        AppPillButton(
+                          label: context.l10n.homeComplete,
+                          onPressed: onComplete,
+                          leading: const Icon(
+                            Icons.check,
+                            fontWeight: FontWeight.w700,
+                          ),
+                          tintColor: task.color,
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/lib/ui/common/components/app_task_list_item.dart
+++ b/lib/ui/common/components/app_task_list_item.dart
@@ -35,9 +35,11 @@ class AppTaskListItem extends StatelessWidget {
             Expanded(
               child: InkWell(
                 highlightColor: task.color
-                    .softColor(context)
-                    .withValues(alpha: 0.2),
-                splashColor: task.color.softColor(context),
+                    .baseColor(context)
+                    .withValues(alpha: 0.08),
+                splashColor: task.color
+                    .baseColor(context)
+                    .withValues(alpha: 0.1),
                 onTap: onTap,
                 child: Ink(
                   child: Padding(


### PR DESCRIPTION
## Summary

- `AppTaskListItem` のタップ時の `highlightColor` / `splashColor` にタスクカラーを適用
- `AppPillButton` に `tintColor` パラメータを追加し、タスクカラーで色付け可能に

## Test plan

- [x] タスクリストのリストアイテムをタップしたときに、タスクカラーでリップルが出ることを確認
- [x] 完了ボタンがタスクカラーで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)