### PR TITLE
AppProgressBar のアニメーション仕様変更とウィジェット分割

### DIFF
--- a/lib/ui/common/components/app_progress_bar.dart
+++ b/lib/ui/common/components/app_progress_bar.dart
@@ -3,7 +3,7 @@ import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
-class AppProgressBar extends StatefulWidget {
+class AppProgressBar extends StatelessWidget {
   const AppProgressBar({
     super.key,
     required this.value,
@@ -19,33 +19,126 @@ class AppProgressBar extends StatefulWidget {
   /// バーの太さ (dp)
   final double thickness;
 
+  static ({Color base, Color soft}) _barColors(
+    AppColorScheme c,
+    double value,
+    bool isOverdue,
+  ) {
+    if (isOverdue) return (base: c.danger, soft: c.dangerSoft);
+    if (value >= 0.75) return (base: c.warning, soft: c.warningSoft);
+    if (value >= 0.5) return (base: c.success, soft: c.successSoft);
+    return (base: c.info, soft: c.infoSoft);
+  }
+
   @override
-  State<AppProgressBar> createState() => _AppProgressBarState();
+  Widget build(BuildContext context) {
+    final c = context.appColorScheme;
+    final (:base, :soft) = _barColors(c, value, isOverdue);
+    final highlightColor = Color.lerp(base, soft, 0.6)!;
+    final clamped = value.clamp(0.0, 1.0);
+
+    if (value >= 1.0) {
+      return _BlinkBar(
+        clamped: clamped,
+        baseColor: base,
+        highlightColor: highlightColor,
+        trackBg: c.trackBg,
+        thickness: thickness,
+      );
+    }
+    if (value <= 0.25) {
+      return _StaticBar(
+        clamped: clamped,
+        baseColor: base,
+        trackBg: c.trackBg,
+        thickness: thickness,
+      );
+    }
+    return _GlimmerBar(
+      clamped: clamped,
+      baseColor: base,
+      highlightColor: highlightColor,
+      trackBg: c.trackBg,
+      thickness: thickness,
+    );
+  }
 }
 
-class _AppProgressBarState extends State<AppProgressBar>
-    with SingleTickerProviderStateMixin {
-  late AnimationController _controller;
+class _StaticBar extends StatelessWidget {
+  const _StaticBar({
+    required this.clamped,
+    required this.baseColor,
+    required this.trackBg,
+    required this.thickness,
+  });
 
-  Duration get _duration => widget.isOverdue
-      ? const Duration(milliseconds: 500)
-      : const Duration(milliseconds: 2600);
+  final double clamped;
+  final Color baseColor;
+  final Color trackBg;
+  final double thickness;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppRadius.pill),
+      child: Container(
+        height: thickness,
+        color: trackBg,
+        alignment: Alignment.centerLeft,
+        child: FractionallySizedBox(
+          widthFactor: clamped,
+          heightFactor: 1.0,
+          child: ColoredBox(color: baseColor),
+        ),
+      ),
+    );
+  }
+}
+
+class _GlimmerBar extends StatefulWidget {
+  const _GlimmerBar({
+    required this.clamped,
+    required this.baseColor,
+    required this.highlightColor,
+    required this.trackBg,
+    required this.thickness,
+  });
+
+  final double clamped;
+  final Color baseColor;
+  final Color highlightColor;
+  final Color trackBg;
+  final double thickness;
+
+  @override
+  State<_GlimmerBar> createState() => _GlimmerBarState();
+}
+
+class _GlimmerBarState extends State<_GlimmerBar>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  // Phase 1 (0.0→0.8): グラデーションが右へ伸長
+  late final Animation<double> _phase1;
+
+  // Phase 2 (0.8→1.0): フェードアウト
+  late final Animation<double> _phase2;
 
   @override
   void initState() {
     super.initState();
-    _controller = AnimationController(vsync: this, duration: _duration)
-      ..repeat(reverse: widget.isOverdue);
-  }
-
-  @override
-  void didUpdateWidget(AppProgressBar oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.isOverdue != widget.isOverdue) {
-      _controller
-        ..duration = _duration
-        ..repeat(reverse: widget.isOverdue);
-    }
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 2600),
+    )..repeat();
+    _phase1 = CurvedAnimation(
+      parent: _controller,
+      curve: const Interval(0.0, 0.8, curve: Curves.easeOut),
+    );
+    _phase2 = CurvedAnimation(
+      parent: _controller,
+      curve: const Interval(0.8, 1.0, curve: Curves.linear),
+    );
   }
 
   @override
@@ -54,71 +147,29 @@ class _AppProgressBarState extends State<AppProgressBar>
     super.dispose();
   }
 
-  Color _barColor(AppColorScheme c) {
-    if (widget.isOverdue) return c.danger;
-    if (widget.value >= 0.75) return c.warning;
-    if (widget.value >= 0.5) return c.success;
-    return c.info;
-  }
-
-  Color _barSoftColor(AppColorScheme c) {
-    if (widget.isOverdue) return c.dangerSoft;
-    if (widget.value >= 0.75) return c.warningSoft;
-    if (widget.value >= 0.5) return c.successSoft;
-    return c.infoSoft;
-  }
-
-  Color _barHighlightColor(AppColorScheme c) =>
-      Color.lerp(_barColor(c), _barSoftColor(c), 0.6)!;
-
   @override
   Widget build(BuildContext context) {
-    final c = context.appColorScheme;
-    final baseColor = _barColor(c);
-    final highlightColor = _barHighlightColor(c);
-    final clamped = widget.value.clamp(0.0, 1.0);
-
     return ClipRRect(
       borderRadius: BorderRadius.circular(AppRadius.pill),
       child: Container(
         height: widget.thickness,
-        color: c.trackBg,
+        color: widget.trackBg,
         alignment: Alignment.centerLeft,
         child: FractionallySizedBox(
-          widthFactor: clamped,
+          widthFactor: widget.clamped,
           heightFactor: 1.0,
           child: LayoutBuilder(
             builder: (context, constraints) {
               return AnimatedBuilder(
                 animation: _controller,
                 builder: (context, _) {
-                  if (widget.isOverdue) {
-                    // 期限切れの場合は点滅
-                    return ColoredBox(
-                      color: Color.lerp(
-                        highlightColor,
-                        baseColor,
-                        _controller.value,
-                      )!,
-                    );
-                  }
-
-                  // Phase 1 (0.0→0.7): グラデーションが右へ伸長
-                  // Phase 2 (0.7→1.0): フェードアウト
-                  final t = _controller.value;
-                  final double width;
-                  final double alpha;
-                  if (t <= 0.7) {
-                    width = constraints.maxWidth * (t / 0.7);
-                    alpha = 1.0;
-                  } else {
-                    width = constraints.maxWidth;
-                    alpha = 1.0 - (t - 0.7) / 0.3;
-                  }
-
+                  final width = constraints.maxWidth * _phase1.value;
+                  final alpha = 1.0 - _phase2.value;
                   return Stack(
                     children: [
-                      Positioned.fill(child: ColoredBox(color: baseColor)),
+                      Positioned.fill(
+                        child: ColoredBox(color: widget.baseColor),
+                      ),
                       Container(
                         width: width,
                         decoration: BoxDecoration(
@@ -126,8 +177,8 @@ class _AppProgressBarState extends State<AppProgressBar>
                             begin: Alignment.centerLeft,
                             end: Alignment.centerRight,
                             colors: [
-                              baseColor.withValues(alpha: alpha),
-                              highlightColor.withValues(alpha: alpha),
+                              widget.baseColor.withValues(alpha: alpha),
+                              widget.highlightColor.withValues(alpha: alpha),
                             ],
                           ),
                         ),
@@ -140,6 +191,90 @@ class _AppProgressBarState extends State<AppProgressBar>
           ),
         ),
       ),
+    );
+  }
+}
+
+class _BlinkBar extends StatefulWidget {
+  const _BlinkBar({
+    required this.clamped,
+    required this.baseColor,
+    required this.highlightColor,
+    required this.trackBg,
+    required this.thickness,
+  });
+
+  final double clamped;
+  final Color baseColor;
+  final Color highlightColor;
+  final Color trackBg;
+  final double thickness;
+
+  @override
+  State<_BlinkBar> createState() => _BlinkBarState();
+}
+
+class _BlinkBarState extends State<_BlinkBar>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 500),
+    )..repeat(reverse: true);
+    _animation = CurvedAnimation(parent: _controller, curve: Curves.easeInOut);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _animation,
+      builder: (context, _) {
+        final t = _animation.value;
+        final blendedColor = Color.lerp(
+          widget.highlightColor,
+          widget.baseColor,
+          t,
+        )!;
+        // base側（t=1, 強烈な色）でグロー最大
+        final glowAlpha = t * 0.5;
+
+        return Container(
+          height: widget.thickness,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(AppRadius.pill),
+            boxShadow: [
+              BoxShadow(
+                color: widget.baseColor.withValues(alpha: glowAlpha),
+                blurRadius: 6,
+                spreadRadius: 2,
+              ),
+            ],
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(AppRadius.pill),
+            child: Container(
+              color: widget.trackBg,
+              alignment: Alignment.centerLeft,
+              child: FractionallySizedBox(
+                widthFactor: widget.clamped,
+                heightFactor: 1.0,
+                child: ColoredBox(color: blendedColor),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }
@@ -163,9 +298,11 @@ final class ProgressBarShowCase extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           spacing: 16,
           children: [
-            AppProgressBar(value: 0.2),
+            AppProgressBar(value: 0.15),
+            AppProgressBar(value: 0.25),
             AppProgressBar(value: 0.55),
             AppProgressBar(value: 0.85),
+            AppProgressBar(value: 1.0, isOverdue: false),
             AppProgressBar(value: 1.0, isOverdue: true),
           ],
         ),


### PR DESCRIPTION
## Summary

- アニメーション条件に応じてウィジェットを3つに分割（`_StaticBar` / `_GlimmerBar` / `_BlinkBar`）
- 25%以下: アニメーションなし
- 25%超〜100%未満: `CurvedAnimation` + `Interval` でEasing付きグラデーションシマー
- 100%以上: 点滅 + 周辺グロー（`isOverdue=true` → danger赤、`isOverdue=false` → warning オレンジ）
- `_barColor` / `_barSoftColor` をDartレコード返しの `_barColors` に統合

## Test plan

- [x] 各バリエーション（15%, 25%, 55%, 85%, 100% overdue, 100% non-overdue）をプレビューで目視確認
- [x] isOverdue=true で赤点滅＋グロー、isOverdue=false かつ value>=1.0 でオレンジ点滅＋グローになること
- [x] 25%以下でアニメーションが止まること
- [x] アニメーション切り替え時（25%境界をまたぐとき）にクラッシュしないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)