### PR TITLE
設定画面にバージョン表示を追加

### DIFF
--- a/lib/app/app_router.dart
+++ b/lib/app/app_router.dart
@@ -1,9 +1,12 @@
+import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/data/preferences/preferences_manager.dart';
 import 'package:dawnbreaker/ui/app_detail/widgets/app_detail_screen.dart';
 import 'package:dawnbreaker/ui/editor/widgets/editor_screen.dart';
 import 'package:dawnbreaker/ui/home/widgets/home_screen.dart';
 import 'package:dawnbreaker/ui/onboarding/widget/onboarding_mode.dart';
 import 'package:dawnbreaker/ui/onboarding/widget/onboarding_screen.dart';
+import 'package:dawnbreaker/ui/settings/widget/settings_screen.dart';
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -34,6 +37,21 @@ GoRouter appRouter(Ref ref) {
             path: 'edit',
             builder: (_, state) => EditorScreen(
               taskId: int.parse(state.pathParameters['taskId']!),
+            ),
+          ),
+        ],
+      ),
+      GoRoute(
+        path: '/settings',
+        builder: (_, _) => const SettingsScreen(),
+        routes: [
+          GoRoute(
+            path: 'licenses',
+            builder: (context, _) => Theme(
+              data: Theme.of(
+                context,
+              ).copyWith(cardColor: context.appColorScheme.bg),
+              child: const LicensePage(),
             ),
           ),
         ],

--- a/lib/ui/common/components/app_section_header.dart
+++ b/lib/ui/common/components/app_section_header.dart
@@ -31,6 +31,7 @@ class AppSectionHeader extends StatelessWidget {
             Flexible(
               child: DefaultTextStyle(
                 style: AppTextStyle.overline.copyWith(
+                  fontWeight: .w700,
                   color: colors.textMuted,
                   overflow: TextOverflow.ellipsis,
                 ),

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -14,7 +14,6 @@ import 'package:dawnbreaker/ui/home/viewmodel/home_task_list.dart';
 import 'package:dawnbreaker/ui/home/viewmodel/home_ui_state.dart';
 import 'package:dawnbreaker/ui/home/viewmodel/home_view_model.dart';
 import 'package:dawnbreaker/ui/home/widgets/task_complete_sheet.dart';
-import 'package:dawnbreaker/ui/onboarding/widget/onboarding_mode.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -214,8 +213,7 @@ class _HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
           icon: Icons.add,
         ),
         AppIconButton(
-          onTap: () =>
-              context.push('/onboarding', extra: OnboardingMode.fromSettings),
+          onTap: () => context.push('/settings'),
           icon: Icons.settings_outlined,
         ),
       ],

--- a/lib/ui/settings/viewmodel/settings_ui_state.dart
+++ b/lib/ui/settings/viewmodel/settings_ui_state.dart
@@ -1,0 +1,16 @@
+import 'package:dawnbreaker/ui/common/base_ui_state.dart';
+import 'package:dawnbreaker/ui/common/error_message.dart';
+import 'package:dawnbreaker/ui/common/snack_bar_message.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'settings_ui_state.freezed.dart';
+
+@freezed
+abstract class SettingsUiState with _$SettingsUiState implements BaseUiState {
+  const factory SettingsUiState({
+    @Default(true) bool isLoading,
+    @Default('') String version,
+    ErrorMessage? errorMessage,
+    SnackBarMessage? snackBarMessage,
+  }) = _SettingsUiState;
+}

--- a/lib/ui/settings/viewmodel/settings_view_model.dart
+++ b/lib/ui/settings/viewmodel/settings_view_model.dart
@@ -1,0 +1,20 @@
+import 'package:dawnbreaker/ui/settings/viewmodel/settings_ui_state.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'settings_view_model.g.dart';
+
+@riverpod
+class SettingsViewModel extends _$SettingsViewModel {
+  @override
+  SettingsUiState build() {
+    _initialize();
+    return const SettingsUiState();
+  }
+
+  Future<void> _initialize() async {
+    final info = await PackageInfo.fromPlatform();
+    if (!ref.mounted) return;
+    state = state.copyWith(isLoading: false, version: info.version);
+  }
+}

--- a/lib/ui/settings/widget/settings_screen.dart
+++ b/lib/ui/settings/widget/settings_screen.dart
@@ -1,0 +1,78 @@
+import 'package:dawnbreaker/app/app_colors.dart';
+import 'package:dawnbreaker/ui/common/components/app_app_bar.dart';
+import 'package:dawnbreaker/ui/common/components/app_list_cell.dart';
+import 'package:dawnbreaker/ui/common/components/app_section_header.dart';
+import 'package:dawnbreaker/ui/onboarding/widget/onboarding_mode.dart';
+import 'package:dawnbreaker/ui/settings/viewmodel/settings_view_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+class SettingsScreen extends ConsumerStatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(settingsViewModelProvider);
+    final padding = MediaQuery.paddingOf(context);
+    return Scaffold(
+      appBar: AppAppBar(title: '設定', onBack: () => context.pop()),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.fromLTRB(20, 8, 20, padding.bottom + 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [..._infoSection(context, state.version)],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _infoSection(BuildContext context, String version) {
+    final colorScheme = context.appColorScheme;
+    final divider = Divider(height: 1, color: colorScheme.divider);
+    return [
+      AppSectionHeader(
+        title: Text('情報'),
+        padding: const EdgeInsets.symmetric(vertical: 8),
+      ),
+      AppListCell(
+        type: .top,
+        child: ListTile(title: Text('バージョン'), trailing: Text(version)),
+      ),
+      divider,
+      AppListCell(
+        type: .middle,
+        child: ListTile(
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          title: Text('チュートリアル'),
+          trailing: Icon(
+            Icons.arrow_forward_ios,
+            size: 16,
+            color: colorScheme.textMuted,
+          ),
+          onTap: () =>
+              context.push('/onboarding', extra: OnboardingMode.fromSettings),
+        ),
+      ),
+      divider,
+      AppListCell(
+        type: .bottom,
+        child: ListTile(
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          title: Text('オープンソースライセンス'),
+          trailing: Icon(
+            Icons.arrow_forward_ios,
+            size: 16,
+            color: colorScheme.textMuted,
+          ),
+          onTap: () => context.push('/settings/licenses'),
+        ),
+      ),
+    ];
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -265,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -373,6 +381,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -549,6 +565,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   path:
     dependency: transitive
     description:
@@ -994,6 +1026,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: ba7d5750e3441caa1bbe31d9e516348fcf8dfcb32aa29ef87a844a59f4d1f1d0
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   animated_list_plus: ^0.5.0
   smooth_page_indicator: ^2.0.1
   shared_preferences: ^2.3.5
+  package_info_plus: ^10.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/ui/settings/viewmodel/settings_view_model_test.dart
+++ b/test/ui/settings/viewmodel/settings_view_model_test.dart
@@ -1,0 +1,52 @@
+import 'package:dawnbreaker/ui/settings/viewmodel/settings_view_model.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SettingsViewModel', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      PackageInfo.setMockInitialValues(
+        appName: 'dawnbreaker',
+        packageName: 'com.example.dawnbreaker',
+        version: '1.2.3',
+        buildNumber: '42',
+        buildSignature: '',
+      );
+      container = ProviderContainer();
+    });
+
+    tearDown(() => container.dispose());
+
+    group('初期状態', () {
+      test('バージョンが読み込み中である', () {
+        final state = container.read(settingsViewModelProvider);
+        expect(state.isLoading, true);
+      });
+
+      test('バージョンが空である', () {
+        final state = container.read(settingsViewModelProvider);
+        expect(state.version, isEmpty);
+      });
+    });
+
+    group('ロード後', () {
+      setUp(() async {
+        container.read(settingsViewModelProvider);
+        await Future<void>.microtask(() {});
+      });
+
+      test('バージョンが表示される', () {
+        expect(container.read(settingsViewModelProvider).version, '1.2.3');
+      });
+
+      test('読み込みが完了している', () {
+        expect(container.read(settingsViewModelProvider).isLoading, false);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- `AppListCell` を使って設定画面のUIを実装
- `package_info_plus` を追加し、SettingsViewModel でバージョン名を取得・表示
- ライセンスページを go_router に追加し、背景色をアプリテーマに合わせて適用

## Test plan

- [x] SettingsViewModel のユニットテストが通ること (`test/ui/settings/viewmodel/settings_view_model_test.dart`)
- [x] 設定画面でアプリバージョンが正しく表示されること
- [x] 「チュートリアル」タップでオンボーディング画面に遷移すること
- [x] 「オープンソースライセンス」タップでライセンスページに遷移し、背景色がテーマと一致すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)