### PR TITLE
設定画面の文字列をローカライズ

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -133,5 +133,10 @@
   "onboardingDemoTask5": "Sneaker wash",
   "onboardingNext": "Next",
   "onboardingSkip": "Skip",
-  "onboardingStart": "Register your first task"
+  "onboardingStart": "Register your first task",
+  "settingsTitle": "Settings",
+  "settingsSectionInfo": "Info",
+  "settingsVersion": "Version",
+  "settingsTutorial": "Tutorial",
+  "settingsLicense": "Open Source Licenses"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -133,5 +133,10 @@
   "onboardingDemoTask5": "スニーカーの洗濯",
   "onboardingNext": "次へ",
   "onboardingSkip": "スキップ",
-  "onboardingStart": "最初のタスクを登録する"
+  "onboardingStart": "最初のタスクを登録する",
+  "settingsTitle": "設定",
+  "settingsSectionInfo": "情報",
+  "settingsVersion": "バージョン",
+  "settingsTutorial": "チュートリアル",
+  "settingsLicense": "オープンソースライセンス"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -613,6 +613,36 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'最初のタスクを登録する'**
   String get onboardingStart;
+
+  /// No description provided for @settingsTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'設定'**
+  String get settingsTitle;
+
+  /// No description provided for @settingsSectionInfo.
+  ///
+  /// In ja, this message translates to:
+  /// **'情報'**
+  String get settingsSectionInfo;
+
+  /// No description provided for @settingsVersion.
+  ///
+  /// In ja, this message translates to:
+  /// **'バージョン'**
+  String get settingsVersion;
+
+  /// No description provided for @settingsTutorial.
+  ///
+  /// In ja, this message translates to:
+  /// **'チュートリアル'**
+  String get settingsTutorial;
+
+  /// No description provided for @settingsLicense.
+  ///
+  /// In ja, this message translates to:
+  /// **'オープンソースライセンス'**
+  String get settingsLicense;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -289,4 +289,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get onboardingStart => 'Register your first task';
+
+  @override
+  String get settingsTitle => 'Settings';
+
+  @override
+  String get settingsSectionInfo => 'Info';
+
+  @override
+  String get settingsVersion => 'Version';
+
+  @override
+  String get settingsTutorial => 'Tutorial';
+
+  @override
+  String get settingsLicense => 'Open Source Licenses';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -284,4 +284,19 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get onboardingStart => '最初のタスクを登録する';
+
+  @override
+  String get settingsTitle => '設定';
+
+  @override
+  String get settingsSectionInfo => '情報';
+
+  @override
+  String get settingsVersion => 'バージョン';
+
+  @override
+  String get settingsTutorial => 'チュートリアル';
+
+  @override
+  String get settingsLicense => 'オープンソースライセンス';
 }

--- a/lib/ui/settings/widget/settings_screen.dart
+++ b/lib/ui/settings/widget/settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:dawnbreaker/app/app_colors.dart';
+import 'package:dawnbreaker/app/app_typography.dart';
 import 'package:dawnbreaker/core/context_extension.dart';
 import 'package:dawnbreaker/ui/common/components/app_app_bar.dart';
 import 'package:dawnbreaker/ui/common/components/app_list_cell.dart';
@@ -9,17 +10,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class SettingsScreen extends ConsumerStatefulWidget {
+class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
   @override
-  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
-}
-
-class _SettingsScreenState extends ConsumerState<SettingsScreen> {
-  @override
-  Widget build(BuildContext context) {
-    final state = ref.watch(settingsViewModelProvider);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final viewState = ref.watch(settingsViewModelProvider);
     final padding = MediaQuery.paddingOf(context);
     return Scaffold(
       appBar: AppAppBar(
@@ -30,7 +26,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         padding: EdgeInsets.fromLTRB(20, 8, 20, padding.bottom + 16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: [..._infoSection(context, state.version)],
+          children: [..._infoSection(context, viewState.version)],
         ),
       ),
     );
@@ -48,7 +44,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         type: .top,
         child: ListTile(
           title: Text(context.l10n.settingsVersion),
-          trailing: Text(version),
+          trailing: Text(version, style: AppTextStyle.caption),
         ),
       ),
       divider,
@@ -62,9 +58,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             size: 16,
             color: colorScheme.textMuted,
           ),
-          onTap: () =>
-              context.push('/onboarding', extra: OnboardingMode.fromSettings),
         ),
+        onTap: () =>
+            context.push('/onboarding', extra: OnboardingMode.fromSettings),
       ),
       divider,
       AppListCell(
@@ -77,8 +73,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             size: 16,
             color: colorScheme.textMuted,
           ),
-          onTap: () => context.push('/settings/licenses'),
         ),
+        onTap: () => context.push('/settings/licenses'),
       ),
     ];
   }

--- a/lib/ui/settings/widget/settings_screen.dart
+++ b/lib/ui/settings/widget/settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:dawnbreaker/app/app_colors.dart';
+import 'package:dawnbreaker/core/context_extension.dart';
 import 'package:dawnbreaker/ui/common/components/app_app_bar.dart';
 import 'package:dawnbreaker/ui/common/components/app_list_cell.dart';
 import 'package:dawnbreaker/ui/common/components/app_section_header.dart';
@@ -21,7 +22,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final state = ref.watch(settingsViewModelProvider);
     final padding = MediaQuery.paddingOf(context);
     return Scaffold(
-      appBar: AppAppBar(title: '設定', onBack: () => context.pop()),
+      appBar: AppAppBar(
+        title: context.l10n.settingsTitle,
+        onBack: () => context.pop(),
+      ),
       body: SingleChildScrollView(
         padding: EdgeInsets.fromLTRB(20, 8, 20, padding.bottom + 16),
         child: Column(
@@ -37,19 +41,22 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final divider = Divider(height: 1, color: colorScheme.divider);
     return [
       AppSectionHeader(
-        title: Text('情報'),
+        title: Text(context.l10n.settingsSectionInfo),
         padding: const EdgeInsets.symmetric(vertical: 8),
       ),
       AppListCell(
         type: .top,
-        child: ListTile(title: Text('バージョン'), trailing: Text(version)),
+        child: ListTile(
+          title: Text(context.l10n.settingsVersion),
+          trailing: Text(version),
+        ),
       ),
       divider,
       AppListCell(
         type: .middle,
         child: ListTile(
           contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-          title: Text('チュートリアル'),
+          title: Text(context.l10n.settingsTutorial),
           trailing: Icon(
             Icons.arrow_forward_ios,
             size: 16,
@@ -64,7 +71,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         type: .bottom,
         child: ListTile(
           contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-          title: Text('オープンソースライセンス'),
+          title: Text(context.l10n.settingsLicense),
           trailing: Icon(
             Icons.arrow_forward_ios,
             size: 16,


### PR DESCRIPTION
## Summary

- 設定画面のハードコード文字列を ARB ファイルに切り出し (`settingsXxx` プレフィクス)
- 日本語・英語の両ロケールに対応
- `ConsumerStatefulWidget` → `ConsumerWidget` にリファクタ

## Test plan

- [x] 設定画面の各テキスト（タイトル・セクション名・項目名）が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)