### PR TITLE
色の取得方法の修正とプレビューラッパーの追加

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 ignore:
   - "**/*.g.dart"
   - "**/*.freezed.dart"
+  - "lib/generated/**/*.dart"

--- a/lib/app/app_colors.dart
+++ b/lib/app/app_colors.dart
@@ -358,12 +358,12 @@ extension TaskColorContext on TaskColor {
 
 extension AppColors on BuildContext {
   AppColorScheme get appColorScheme =>
-      MediaQuery.platformBrightnessOf(this) == Brightness.dark
+      Theme.of(this).brightness == Brightness.dark
       ? AppColorScheme.dark
       : AppColorScheme.light;
 
   AppTaskColorScheme get appTaskColorScheme =>
-      MediaQuery.platformBrightnessOf(this) == Brightness.dark
+      Theme.of(this).brightness == Brightness.dark
       ? AppTaskColorScheme.dark
       : AppTaskColorScheme.light;
 }

--- a/lib/app/app_theme.dart
+++ b/lib/app/app_theme.dart
@@ -5,61 +5,60 @@ import 'app_radius.dart';
 import 'app_typography.dart';
 
 ThemeData createThemeData(BuildContext context) {
-  final colorScheme = context.appColorScheme;
+  final brightness = MediaQuery.platformBrightnessOf(context);
+  final c = brightness == Brightness.dark
+      ? AppColorScheme.dark
+      : AppColorScheme.light;
   return ThemeData(
     useMaterial3: true,
     colorScheme: ColorScheme.fromSeed(
-      seedColor: colorScheme.primary,
-      brightness: MediaQuery.platformBrightnessOf(context),
+      seedColor: c.primary,
+      brightness: brightness,
     ),
-    scaffoldBackgroundColor: colorScheme.bg,
-    canvasColor: colorScheme.bg,
-    hintColor: colorScheme.textMuted,
-    iconTheme: IconThemeData(color: colorScheme.text),
+    scaffoldBackgroundColor: c.bg,
+    canvasColor: c.bg,
+    hintColor: c.textMuted,
+    iconTheme: IconThemeData(color: c.text),
     appBarTheme: AppBarTheme(
-      backgroundColor: colorScheme.bg,
-      foregroundColor: colorScheme.text,
-      iconTheme: IconThemeData(color: colorScheme.text),
+      backgroundColor: c.bg,
+      foregroundColor: c.text,
+      iconTheme: IconThemeData(color: c.text),
       titleTextStyle: AppTextStyle.body.copyWith(
-        color: colorScheme.text,
+        color: c.text,
         fontWeight: FontWeight.w700,
       ),
       elevation: 0,
       scrolledUnderElevation: 0,
     ),
     cardTheme: CardThemeData(
-      color: colorScheme.surface,
+      color: c.surface,
       elevation: 1,
-      shadowColor: colorScheme.shadow,
+      shadowColor: c.shadow,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(AppRadius.lg),
-        side: BorderSide(color: colorScheme.border),
+        side: BorderSide(color: c.border),
       ),
     ),
-    dividerTheme: DividerThemeData(color: colorScheme.divider),
+    dividerTheme: DividerThemeData(color: c.divider),
     bottomSheetTheme: BottomSheetThemeData(
-      backgroundColor: colorScheme.surface,
+      backgroundColor: c.surface,
       surfaceTintColor: Colors.transparent,
-      dragHandleColor: colorScheme.borderStrong,
+      dragHandleColor: c.borderStrong,
     ),
     dialogTheme: DialogThemeData(
-      backgroundColor: colorScheme.surface,
+      backgroundColor: c.surface,
       surfaceTintColor: Colors.transparent,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(AppRadius.lg),
-        side: BorderSide(color: colorScheme.border),
+        side: BorderSide(color: c.border),
       ),
-      titleTextStyle: AppTextStyle.headline.copyWith(color: colorScheme.text),
-      contentTextStyle: AppTextStyle.caption.copyWith(
-        color: colorScheme.textMuted,
-      ),
+      titleTextStyle: AppTextStyle.headline.copyWith(color: c.text),
+      contentTextStyle: AppTextStyle.caption.copyWith(color: c.textMuted),
     ),
     snackBarTheme: SnackBarThemeData(
-      backgroundColor: colorScheme.text,
-      contentTextStyle: AppTextStyle.body.copyWith(
-        color: colorScheme.textInverse,
-      ),
-      actionTextColor: colorScheme.primaryInverse,
+      backgroundColor: c.text,
+      contentTextStyle: AppTextStyle.body.copyWith(color: c.textInverse),
+      actionTextColor: c.primaryInverse,
     ),
   );
 }

--- a/lib/ui/common/components/app_app_bar.dart
+++ b/lib/ui/common/components/app_app_bar.dart
@@ -1,5 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/ui/common/components/app_icon_button.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -51,34 +52,36 @@ final class AppAppBarShowCase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.appColorScheme;
-    return ColoredBox(
-      color: c.bg,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const AppAppBar(title: 'タイトルのみ'),
-          Divider(height: 1, color: c.divider),
-          AppAppBar(
-            title: 'アクションあり',
-            actions: [
-              AppIconButton(onTap: () {}, icon: Icons.add),
-              const SizedBox(width: 8),
-              AppIconButton(onTap: () {}, icon: Icons.settings_outlined),
-              const SizedBox(width: 4),
-            ],
-          ),
-          Divider(height: 1, color: c.divider),
-          AppAppBar(title: '戻るボタンあり', onBack: () {}),
-          Divider(height: 1, color: c.divider),
-          AppAppBar(
-            title: 'すべてあり',
-            onBack: () {},
-            actions: [
-              AppIconButton(onTap: () {}, icon: Icons.more_vert),
-              const SizedBox(width: 4),
-            ],
-          ),
-        ],
+    return PreviewWrapper(
+      child: ColoredBox(
+        color: c.bg,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const AppAppBar(title: 'タイトルのみ'),
+            Divider(height: 1, color: c.divider),
+            AppAppBar(
+              title: 'アクションあり',
+              actions: [
+                AppIconButton(onTap: () {}, icon: Icons.add),
+                const SizedBox(width: 8),
+                AppIconButton(onTap: () {}, icon: Icons.settings_outlined),
+                const SizedBox(width: 4),
+              ],
+            ),
+            Divider(height: 1, color: c.divider),
+            AppAppBar(title: '戻るボタンあり', onBack: () {}),
+            Divider(height: 1, color: c.divider),
+            AppAppBar(
+              title: 'すべてあり',
+              onBack: () {},
+              actions: [
+                AppIconButton(onTap: () {}, icon: Icons.more_vert),
+                const SizedBox(width: 4),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/common/components/app_badge.dart
+++ b/lib/ui/common/components/app_badge.dart
@@ -1,6 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -61,21 +62,23 @@ final class LabelShowCase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = context.appColorScheme;
-    return Container(
-      color: colorScheme.bg,
-      padding: const EdgeInsets.all(18),
-      alignment: Alignment.center,
-      child: const Row(
-        spacing: 6,
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          AppBadge(label: '中立', tone: AppBadgeTone.neutral),
-          AppBadge(label: '11日超過', tone: AppBadgeTone.danger),
-          AppBadge(label: '今日', tone: AppBadgeTone.warning),
-          AppBadge(label: '完了', tone: AppBadgeTone.success),
-          AppBadge(label: '情報', tone: AppBadgeTone.info),
-          AppBadge(label: '残り6日', tone: AppBadgeTone.primary),
-        ],
+    return PreviewWrapper(
+      child: Container(
+        color: colorScheme.bg,
+        padding: const EdgeInsets.all(18),
+        alignment: Alignment.center,
+        child: const Row(
+          spacing: 6,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            AppBadge(label: '中立', tone: AppBadgeTone.neutral),
+            AppBadge(label: '11日超過', tone: AppBadgeTone.danger),
+            AppBadge(label: '今日', tone: AppBadgeTone.warning),
+            AppBadge(label: '完了', tone: AppBadgeTone.success),
+            AppBadge(label: '情報', tone: AppBadgeTone.info),
+            AppBadge(label: '残り6日', tone: AppBadgeTone.primary),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/common/components/app_button.dart
+++ b/lib/ui/common/components/app_button.dart
@@ -1,6 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -129,72 +130,74 @@ final class ButtonShowCase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.appColorScheme;
-    return Container(
-      color: c.bg,
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        spacing: 16,
-        children: [
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 8,
-            children: [
-              AppButton(label: 'Primary', onPressed: () {}),
-              AppButton(
-                label: 'Secondary',
-                variant: AppButtonVariant.secondary,
-                onPressed: () {},
-              ),
-              AppButton(
-                label: 'Ghost',
-                variant: AppButtonVariant.ghost,
-                onPressed: () {},
-              ),
-              AppButton(
-                label: 'Danger',
-                variant: AppButtonVariant.danger,
-                onPressed: () {},
-              ),
-            ],
-          ),
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            spacing: 8,
-            children: [
-              AppButton(
-                label: 'Small',
-                size: AppButtonSize.small,
-                onPressed: () {},
-              ),
-              AppButton(label: 'Medium', onPressed: () {}),
-              AppButton(
-                label: 'Large',
-                size: AppButtonSize.large,
-                onPressed: () {},
-              ),
-            ],
-          ),
-          const Row(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 8,
-            children: [
-              AppButton(label: 'Primary'),
-              AppButton(
-                label: 'Secondary',
-                variant: AppButtonVariant.secondary,
-              ),
-              AppButton(label: 'Danger', variant: AppButtonVariant.danger),
-            ],
-          ),
-          AppButton(
-            label: '完了',
-            onPressed: () {},
-            leading: const Icon(Icons.check, size: 16),
-          ),
-        ],
+    return PreviewWrapper(
+      child: Container(
+        color: c.bg,
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: 16,
+          children: [
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 8,
+              children: [
+                AppButton(label: 'Primary', onPressed: () {}),
+                AppButton(
+                  label: 'Secondary',
+                  variant: AppButtonVariant.secondary,
+                  onPressed: () {},
+                ),
+                AppButton(
+                  label: 'Ghost',
+                  variant: AppButtonVariant.ghost,
+                  onPressed: () {},
+                ),
+                AppButton(
+                  label: 'Danger',
+                  variant: AppButtonVariant.danger,
+                  onPressed: () {},
+                ),
+              ],
+            ),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              spacing: 8,
+              children: [
+                AppButton(
+                  label: 'Small',
+                  size: AppButtonSize.small,
+                  onPressed: () {},
+                ),
+                AppButton(label: 'Medium', onPressed: () {}),
+                AppButton(
+                  label: 'Large',
+                  size: AppButtonSize.large,
+                  onPressed: () {},
+                ),
+              ],
+            ),
+            const Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 8,
+              children: [
+                AppButton(label: 'Primary'),
+                AppButton(
+                  label: 'Secondary',
+                  variant: AppButtonVariant.secondary,
+                ),
+                AppButton(label: 'Danger', variant: AppButtonVariant.danger),
+              ],
+            ),
+            AppButton(
+              label: '完了',
+              onPressed: () {},
+              leading: const Icon(Icons.check, size: 16),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/common/components/app_dialog.dart
+++ b/lib/ui/common/components/app_dialog.dart
@@ -1,6 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
-import 'package:dawnbreaker/app/app_theme.dart';
 import 'package:dawnbreaker/generated/l10n.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:dawnbreaker/ui/common/components/app_button.dart';
 import 'package:dawnbreaker/ui/common/dialog_message.dart';
 import 'package:flutter/material.dart';
@@ -99,8 +99,7 @@ final class DialogShowCase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.appColorScheme;
-    return Theme(
-      data: createThemeData(context),
+    return PreviewWrapper(
       child: Container(
         color: c.bg,
         padding: const EdgeInsets.all(24),

--- a/lib/ui/common/components/app_filter_chip.dart
+++ b/lib/ui/common/components/app_filter_chip.dart
@@ -1,6 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -75,23 +76,30 @@ final class FilterChipShowCase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.appColorScheme;
-    return Container(
-      color: c.bg,
-      padding: const EdgeInsets.all(24),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        spacing: 6,
-        children: [
-          AppFilterChip(
-            label: 'すべて',
-            isSelected: true,
-            onTap: () {},
-            count: 12,
-          ),
-          AppFilterChip(label: '超過', isSelected: false, onTap: () {}, count: 3),
-          AppFilterChip(label: '今日', isSelected: false, onTap: () {}),
-          AppFilterChip(label: '7日以内', isSelected: false, onTap: () {}),
-        ],
+    return PreviewWrapper(
+      child: Container(
+        color: c.bg,
+        padding: const EdgeInsets.all(24),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 6,
+          children: [
+            AppFilterChip(
+              label: 'すべて',
+              isSelected: true,
+              onTap: () {},
+              count: 12,
+            ),
+            AppFilterChip(
+              label: '超過',
+              isSelected: false,
+              onTap: () {},
+              count: 3,
+            ),
+            AppFilterChip(label: '今日', isSelected: false, onTap: () {}),
+            AppFilterChip(label: '7日以内', isSelected: false, onTap: () {}),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/common/components/app_icon_button.dart
+++ b/lib/ui/common/components/app_icon_button.dart
@@ -2,6 +2,7 @@ import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
 import 'package:dawnbreaker/ui/common/extend_hit_test.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -94,17 +95,19 @@ final class IconButtonShowCase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = context.appColorScheme;
-    return Container(
-      color: colorScheme.bg,
-      padding: const EdgeInsets.all(18),
-      alignment: Alignment.center,
-      child: Row(
-        spacing: 6,
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          AppIconButton(icon: Icons.add_ic_call_outlined, onTap: () {}),
-          AppIconButton(icon: Icons.edit, label: '編集', onTap: () {}),
-        ],
+    return PreviewWrapper(
+      child: Container(
+        color: colorScheme.bg,
+        padding: const EdgeInsets.all(18),
+        alignment: Alignment.center,
+        child: Row(
+          spacing: 6,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            AppIconButton(icon: Icons.add_ic_call_outlined, onTap: () {}),
+            AppIconButton(icon: Icons.edit, label: '編集', onTap: () {}),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/common/components/app_input.dart
+++ b/lib/ui/common/components/app_input.dart
@@ -1,6 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -179,25 +180,27 @@ final class InputShowCase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.appColorScheme;
-    return ColoredBox(
-      color: c.bg,
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: SizedBox(
-          width: 320,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            spacing: 16,
-            children: [
-              const AppTextInput(hintText: 'タスク名を入力'),
-              const AppSearchInput(placeholder: 'タスクを検索'),
-              AppSearchInput(
-                placeholder: '検索中…',
-                showClear: true,
-                onClear: () {},
-              ),
-            ],
+    return PreviewWrapper(
+      child: ColoredBox(
+        color: c.bg,
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: SizedBox(
+            width: 320,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              spacing: 16,
+              children: [
+                const AppTextInput(hintText: 'タスク名を入力'),
+                const AppSearchInput(placeholder: 'タスクを検索'),
+                AppSearchInput(
+                  placeholder: '検索中…',
+                  showClear: true,
+                  onClear: () {},
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/ui/common/components/app_list_cell.dart
+++ b/lib/ui/common/components/app_list_cell.dart
@@ -1,6 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/ui/common/components/app_section_header.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -114,16 +115,18 @@ final class AppListCellShowCase extends StatelessWidget {
       cell(.middle, '3rd line'),
       cell(.bottom, '4th line'),
     ];
-    return Material(
-      color: c.bg,
-      child: Padding(
-        padding: const EdgeInsetsGeometry.all(10),
-        child: ListView.separated(
-          itemCount: items.length,
-          itemBuilder: (context, index) => items[index],
-          separatorBuilder: AppListCell.buildSeparator(
-            items,
-            borderColor: c.border,
+    return PreviewWrapper(
+      child: Material(
+        color: c.bg,
+        child: Padding(
+          padding: const EdgeInsetsGeometry.all(10),
+          child: ListView.separated(
+            itemCount: items.length,
+            itemBuilder: (context, index) => items[index],
+            separatorBuilder: AppListCell.buildSeparator(
+              items,
+              borderColor: c.border,
+            ),
           ),
         ),
       ),

--- a/lib/ui/common/components/app_pill_button.dart
+++ b/lib/ui/common/components/app_pill_button.dart
@@ -1,6 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
 import 'package:dawnbreaker/data/model/task_color.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -82,27 +83,29 @@ final class PillButtonShowCase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.appColorScheme;
-    return Container(
-      color: c.bg,
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        spacing: 12,
-        children: [
-          AppPillButton(
-            label: '完了',
-            onPressed: () {},
-            leading: const Icon(Icons.check),
-          ),
-          AppPillButton(
-            label: '完了',
-            variant: AppPillButtonVariant.secondary,
-            onPressed: () {},
-            leading: const Icon(Icons.check),
-          ),
-          const AppPillButton(label: '完了 (disabled)'),
-        ],
+    return PreviewWrapper(
+      child: Container(
+        color: c.bg,
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: 12,
+          children: [
+            AppPillButton(
+              label: '完了',
+              onPressed: () {},
+              leading: const Icon(Icons.check),
+            ),
+            AppPillButton(
+              label: '完了',
+              variant: AppPillButtonVariant.secondary,
+              onPressed: () {},
+              leading: const Icon(Icons.check),
+            ),
+            const AppPillButton(label: '完了 (disabled)'),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/common/components/app_progress_bar.dart
+++ b/lib/ui/common/components/app_progress_bar.dart
@@ -1,5 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -288,23 +289,25 @@ final class ProgressBarShowCase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.appColorScheme;
-    return Container(
-      color: c.bg,
-      padding: const EdgeInsets.all(24),
-      child: const SizedBox(
-        width: 320,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          spacing: 16,
-          children: [
-            AppProgressBar(value: 0.15),
-            AppProgressBar(value: 0.25),
-            AppProgressBar(value: 0.55),
-            AppProgressBar(value: 0.85),
-            AppProgressBar(value: 1.0, isOverdue: false),
-            AppProgressBar(value: 1.0, isOverdue: true),
-          ],
+    return PreviewWrapper(
+      child: Container(
+        color: c.bg,
+        padding: const EdgeInsets.all(24),
+        child: const SizedBox(
+          width: 320,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            spacing: 16,
+            children: [
+              AppProgressBar(value: 0.15),
+              AppProgressBar(value: 0.25),
+              AppProgressBar(value: 0.55),
+              AppProgressBar(value: 0.85),
+              AppProgressBar(value: 1.0, isOverdue: false),
+              AppProgressBar(value: 1.0, isOverdue: true),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/common/components/app_section_header.dart
+++ b/lib/ui/common/components/app_section_header.dart
@@ -1,5 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -61,27 +62,31 @@ final class AppSectionHeaderShowCase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = context.appColorScheme;
-    return Container(
-      color: c.bg,
-      padding: const EdgeInsets.all(24),
-      child: const SizedBox(
-        width: 320,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          spacing: 16,
-          children: [
-            AppSectionHeader(title: Text('タイトルのみ')),
-            AppSectionHeader(title: Text('タイトルのみ長い文章長い文章長い文章長い文章長い文章長い文章長い文章')),
-            AppSectionHeader(
-              title: Text('タイトルとサブタイトル'),
-              subTitle: Text('サブタイトル'),
-            ),
-            AppSectionHeader(
-              title: Text('前景色・背景色指定', style: TextStyle(color: Colors.white)),
-              backgroundColor: Colors.red,
-            ),
-          ],
+    return PreviewWrapper(
+      child: Container(
+        color: c.bg,
+        padding: const EdgeInsets.all(24),
+        child: const SizedBox(
+          width: 320,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            spacing: 16,
+            children: [
+              AppSectionHeader(title: Text('タイトルのみ')),
+              AppSectionHeader(
+                title: Text('タイトルのみ長い文章長い文章長い文章長い文章長い文章長い文章長い文章'),
+              ),
+              AppSectionHeader(
+                title: Text('タイトルとサブタイトル'),
+                subTitle: Text('サブタイトル'),
+              ),
+              AppSectionHeader(
+                title: Text('前景色・背景色指定', style: TextStyle(color: Colors.white)),
+                backgroundColor: Colors.red,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/common/components/app_snack_bar.dart
+++ b/lib/ui/common/components/app_snack_bar.dart
@@ -1,8 +1,11 @@
 import 'dart:async' show unawaited;
 
 import 'package:dawnbreaker/generated/l10n.dart';
+import 'package:dawnbreaker/ui/common/components/app_button.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:dawnbreaker/ui/common/snack_bar_message.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/widget_previews.dart';
 
 abstract final class AppSnackBar {
   static void show(BuildContext context, SnackBarMessage message) {
@@ -31,6 +34,49 @@ abstract final class AppSnackBar {
     persist: false,
     action: SnackBarAction(label: actionLabel, onPressed: onAction),
   );
+}
+
+@Preview()
+Widget previewSnackBar() => const SnackBarShowCase();
+
+final class SnackBarShowCase extends StatelessWidget {
+  const SnackBarShowCase({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return PreviewWrapper(
+      child: ScaffoldMessenger(
+        child: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                spacing: 12,
+                children: [
+                  AppButton(
+                    label: '完了通知',
+                    onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                      AppSnackBar.create(message: '「オイル交換」の完了を記録しました'),
+                    ),
+                  ),
+                  AppButton(
+                    label: '登録通知（取り消しあり）',
+                    onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                      AppSnackBar.createWithAction(
+                        message: '「歯ブラシ交換」を登録しました',
+                        actionLabel: '取り消し',
+                        onAction: () {},
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 String _messageText(BuildContext context, SnackBarMessage msg) => switch (msg) {

--- a/lib/ui/common/components/app_task_icon_tile.dart
+++ b/lib/ui/common/components/app_task_icon_tile.dart
@@ -1,5 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/data/model/task_color.dart';
+import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
@@ -79,38 +80,40 @@ final class TaskIconTileShowCase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final bg = context.appColorScheme.bg;
-    return Container(
-      color: bg,
-      padding: const EdgeInsets.all(24),
-      child: const Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        spacing: 16,
-        children: [
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 8,
-            children: [
-              AppTaskIconTile(emoji: '🚗', color: TaskColor.none),
-              AppTaskIconTile(emoji: '🌿', color: TaskColor.red),
-              AppTaskIconTile(emoji: '❄️', color: TaskColor.blue),
-              AppTaskIconTile(emoji: '🐝', color: TaskColor.yellow),
-              AppTaskIconTile(emoji: '🪴', color: TaskColor.green),
-              AppTaskIconTile(emoji: '🧺', color: TaskColor.orange),
-            ],
-          ),
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            spacing: 8,
-            children: [
-              AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 32),
-              AppTaskIconTile(emoji: '🚗', color: TaskColor.none),
-              AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 48),
-              AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 52),
-            ],
-          ),
-        ],
+    return PreviewWrapper(
+      child: Container(
+        color: bg,
+        padding: const EdgeInsets.all(24),
+        child: const Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: 16,
+          children: [
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 8,
+              children: [
+                AppTaskIconTile(emoji: '🚗', color: TaskColor.none),
+                AppTaskIconTile(emoji: '🌿', color: TaskColor.red),
+                AppTaskIconTile(emoji: '❄️', color: TaskColor.blue),
+                AppTaskIconTile(emoji: '🐝', color: TaskColor.yellow),
+                AppTaskIconTile(emoji: '🪴', color: TaskColor.green),
+                AppTaskIconTile(emoji: '🧺', color: TaskColor.orange),
+              ],
+            ),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              spacing: 8,
+              children: [
+                AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 32),
+                AppTaskIconTile(emoji: '🚗', color: TaskColor.none),
+                AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 48),
+                AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 52),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/common/components/preview_wrapper.dart
+++ b/lib/ui/common/components/preview_wrapper.dart
@@ -1,0 +1,13 @@
+import 'package:dawnbreaker/app/app_theme.dart';
+import 'package:flutter/material.dart';
+
+class PreviewWrapper extends StatelessWidget {
+  const PreviewWrapper({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(data: createThemeData(context), child: child);
+  }
+}


### PR DESCRIPTION
## Summary

- `Theme.of(context).brightness` を使うよう色の取得方法を修正（`MediaQuery.platformBrightnessOf` からの変更）
- `PreviewWrapper` コンポーネントを追加し、各 ShowCase ウィジェットに適用（テーマが正しく反映されるよう統一）
- `lib/generated/**/*.dart` を codecov の ignore 対象に追加

## Test plan

- [x] ライト/ダークモード切り替え時に色が正しく反映されることを確認
- [x] Widget Preview で各コンポーネントのテーマが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)