### PR TITLE
UI改善（タスク詳細画面から完了の導線追加など）

### DIFF
--- a/lib/app/app_theme.dart
+++ b/lib/app/app_theme.dart
@@ -44,6 +44,10 @@ ThemeData createThemeData(BuildContext context) {
       backgroundColor: c.surface,
       surfaceTintColor: Colors.transparent,
       dragHandleColor: c.borderStrong,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        side: BorderSide(color: c.border),
+      ),
     ),
     dialogTheme: DialogThemeData(
       backgroundColor: c.surface,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8,6 +8,8 @@
     }
   },
   "title": "Dawnbreaker",
+  "homeBarAdd": "Add",
+  "homeBarSettings": "Settings",
   "homeSearchHint": "Search tasks",
   "homeNoTasksYet": "No tasks yet",
   "homeNoTasksFound": "No matching tasks found",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -22,6 +22,8 @@
   "homeComplete": "Done",
   "homeCompleteSheetTitle": "Complete task",
   "homeCompleteRecord": "Record completion",
+  "homeCompleteDateLabel": "Completion date",
+  "homeCompleteCommentLabel": "Comment",
   "homeCompleteCommentPlaceholder": "Add a comment (optional)",
   "homeCompleteSuccess": "Marked \"{name}\" as complete",
   "@homeCompleteSuccess": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -141,6 +141,7 @@
       }
     }
   },
+  "appDetailRecordCompletion": "Record task completion",
   "appDetailUpdateHistorySuccess": "History updated",
   "appDetailTaskDeleteConfirm": "Delete task “{name}”?",
   "@appDetailTaskDeleteConfirm": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,6 +1,8 @@
 {
   "@@locale": "ja",
   "title": "Dawnbreaker",
+  "homeBarAdd": "追加",
+  "homeBarSettings": "設定",
   "homeSearchHint": "タスクを検索",
   "homeNoTasksYet": "タスクがまだありません",
   "homeNoTasksFound": "一致するタスクが見つかりません",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -141,6 +141,7 @@
       }
     }
   },
+  "appDetailRecordCompletion": "タスクの完了を登録する",
   "appDetailUpdateHistorySuccess": "履歴を更新しました",
   "appDetailTaskDeleteConfirm": "タスク「{name}」を削除しますか？",
   "@appDetailTaskDeleteConfirm": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -15,6 +15,8 @@
   "homeComplete": "完了",
   "homeCompleteSheetTitle": "タスクを完了",
   "homeCompleteRecord": "完了を記録",
+  "homeCompleteDateLabel": "完了日",
+  "homeCompleteCommentLabel": "コメント",
   "homeCompleteCommentPlaceholder": "コメントを入力（任意）",
   "homeCompleteSuccess": "「{name}」の完了を記録しました",
   "@homeCompleteSuccess": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -104,6 +104,18 @@ abstract class AppLocalizations {
   /// **'Dawnbreaker'**
   String get title;
 
+  /// No description provided for @homeBarAdd.
+  ///
+  /// In ja, this message translates to:
+  /// **'追加'**
+  String get homeBarAdd;
+
+  /// No description provided for @homeBarSettings.
+  ///
+  /// In ja, this message translates to:
+  /// **'設定'**
+  String get homeBarSettings;
+
   /// No description provided for @homeSearchHint.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -530,6 +530,12 @@ abstract class AppLocalizations {
   /// **'定期 {value}{unit}'**
   String appDetailTypeBadgeScheduled(int value, String unit);
 
+  /// No description provided for @appDetailRecordCompletion.
+  ///
+  /// In ja, this message translates to:
+  /// **'タスクの完了を登録する'**
+  String get appDetailRecordCompletion;
+
   /// No description provided for @appDetailUpdateHistorySuccess.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -188,6 +188,18 @@ abstract class AppLocalizations {
   /// **'完了を記録'**
   String get homeCompleteRecord;
 
+  /// No description provided for @homeCompleteDateLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'完了日'**
+  String get homeCompleteDateLabel;
+
+  /// No description provided for @homeCompleteCommentLabel.
+  ///
+  /// In ja, this message translates to:
+  /// **'コメント'**
+  String get homeCompleteCommentLabel;
+
   /// No description provided for @homeCompleteCommentPlaceholder.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -244,6 +244,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get appDetailRecordCompletion => 'Record task completion';
+
+  @override
   String get appDetailUpdateHistorySuccess => 'History updated';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -12,6 +12,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get title => 'Dawnbreaker';
 
   @override
+  String get homeBarAdd => 'Add';
+
+  @override
+  String get homeBarSettings => 'Settings';
+
+  @override
   String get homeSearchHint => 'Search tasks';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -54,6 +54,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeCompleteRecord => 'Record completion';
 
   @override
+  String get homeCompleteDateLabel => 'Completion date';
+
+  @override
+  String get homeCompleteCommentLabel => 'Comment';
+
+  @override
   String get homeCompleteCommentPlaceholder => 'Add a comment (optional)';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -54,6 +54,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get homeCompleteRecord => '完了を記録';
 
   @override
+  String get homeCompleteDateLabel => '完了日';
+
+  @override
+  String get homeCompleteCommentLabel => 'コメント';
+
+  @override
   String get homeCompleteCommentPlaceholder => 'コメントを入力（任意）';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -243,6 +243,9 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get appDetailRecordCompletion => 'タスクの完了を登録する';
+
+  @override
   String get appDetailUpdateHistorySuccess => '履歴を更新しました';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -12,6 +12,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get title => 'Dawnbreaker';
 
   @override
+  String get homeBarAdd => '追加';
+
+  @override
+  String get homeBarSettings => '設定';
+
+  @override
   String get homeSearchHint => 'タスクを検索';
 
   @override

--- a/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
+++ b/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:dawnbreaker/data/model/task_history.dart';
+import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository_exception.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository_impl.dart';
@@ -107,6 +108,34 @@ class AppDetailViewModel extends _$AppDetailViewModel {
       if (!ref.mounted) return;
       state = state.copyWith(
         dialogMessage: TaskDeleteErrorMessage(handler: deleteTask),
+      );
+    }
+  }
+
+  Future<void> recordExecution(
+    TaskItem task,
+    DateTime executedAt,
+    String? comment,
+  ) async {
+    try {
+      final history = await _repository.recordExecution(
+        task.id,
+        executedAt: executedAt,
+        comment: comment,
+      );
+      if (!ref.mounted) return;
+      state = state.copyWith(
+        snackBarMessage: TaskCompleteSuccess(
+          taskName: task.name,
+          handler: () => _repository.deleteExecution(history.id),
+        ),
+      );
+    } on TaskRepositoryException {
+      if (!ref.mounted) return;
+      state = state.copyWith(
+        dialogMessage: TaskSaveErrorMessage(
+          handler: () => recordExecution(task, executedAt, comment),
+        ),
       );
     }
   }

--- a/lib/ui/app_detail/widgets/app_detail_history_item.dart
+++ b/lib/ui/app_detail/widgets/app_detail_history_item.dart
@@ -1,0 +1,147 @@
+import 'package:dawnbreaker/app/app_colors.dart';
+import 'package:dawnbreaker/app/app_radius.dart';
+import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:dawnbreaker/core/util/context_extension.dart';
+import 'package:dawnbreaker/core/util/date_util.dart';
+import 'package:dawnbreaker/data/model/task_color.dart';
+import 'package:dawnbreaker/data/model/task_history.dart';
+import 'package:dawnbreaker/ui/common/components/app_list_cell.dart';
+import 'package:flutter/material.dart';
+
+class AppDetailHistoryItem extends StatelessWidget {
+  const AppDetailHistoryItem({
+    super.key,
+    required this.entry,
+    required this.isFirst,
+    required this.isLast,
+    required this.taskColor,
+    required this.intervalDays,
+    this.onTap,
+  });
+
+  final TaskHistory entry;
+  final bool isFirst;
+  final bool isLast;
+  final TaskColor taskColor;
+  final int? intervalDays;
+  final VoidCallback? onTap;
+
+  static const _dotSize = 10.0;
+  static const _lineWidth = 1.5;
+  static const _paddingH = 20.0;
+  static const _paddingV = 14.0;
+  static const _dotTopY = _paddingV + 4.0;
+  static const _dotBottomY = _dotTopY + _dotSize;
+  static const _lineLeft = _paddingH + _dotSize / 2 - _lineWidth / 2;
+
+  AppListCellType get _type => switch ((isFirst, isLast)) {
+    (true, true) => .single,
+    (true, false) => .top,
+    (false, true) => .bottom,
+    _ => .middle,
+  };
+
+  BoxDecoration _dotDecoration(Color dotColor, Color surface) => isFirst
+      ? BoxDecoration(color: dotColor, shape: BoxShape.circle)
+      : BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(color: dotColor, width: _lineWidth),
+          color: surface,
+        );
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.appColorScheme;
+    final dotColor = taskColor.baseColor(context);
+
+    return AppListCell(
+      type: _type,
+      onTap: onTap,
+      child: Stack(
+        children: [
+          if (!isFirst || !isLast)
+            Positioned(
+              left: _lineLeft,
+              width: _lineWidth,
+              top: isFirst ? _dotBottomY : 0,
+              bottom: isLast ? null : 0,
+              height: isLast ? _dotTopY : null,
+              child: ColoredBox(color: colors.divider),
+            ),
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              _paddingH,
+              _paddingV,
+              _paddingH,
+              entry.comment == null ? _paddingV : 8,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Container(
+                      width: _dotSize,
+                      height: _dotSize,
+                      decoration: _dotDecoration(dotColor, colors.surface),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        DateUtil.format(context, entry.executedAt),
+                        style: AppTextStyle.body.copyWith(
+                          color: colors.text,
+                          fontWeight: isFirst
+                              ? FontWeight.w600
+                              : FontWeight.w400,
+                        ),
+                      ),
+                    ),
+                    if (intervalDays != null)
+                      Text(
+                        intervalDays! == 0
+                            ? context.l10n.commonToday
+                            : context.l10n.appDetailDaysInterval(intervalDays!),
+                        style: AppTextStyle.caption.copyWith(
+                          color: colors.textMuted,
+                        ),
+                      ),
+                  ],
+                ),
+                if (entry.comment case final comment?)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8, left: _dotSize + 12),
+                    child: _HistoryComment(comment: comment),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HistoryComment extends StatelessWidget {
+  const _HistoryComment({required this.comment});
+
+  final String comment;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.appColorScheme;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: colors.border),
+        borderRadius: BorderRadius.circular(AppRadius.md),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: Text(
+          comment,
+          style: AppTextStyle.caption.copyWith(color: colors.textSubtle),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/app_detail/widgets/app_detail_screen.dart
+++ b/lib/ui/app_detail/widgets/app_detail_screen.dart
@@ -2,17 +2,16 @@ import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
 import 'package:dawnbreaker/core/util/context_extension.dart';
-import 'package:dawnbreaker/core/util/date_util.dart';
 import 'package:dawnbreaker/data/model/task_color.dart';
 import 'package:dawnbreaker/data/model/task_history.dart';
 import 'package:dawnbreaker/data/model/task_history_stats.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/ui/app_detail/viewmodel/app_detail_view_model.dart';
+import 'package:dawnbreaker/ui/app_detail/widgets/app_detail_history_item.dart';
 import 'package:dawnbreaker/ui/app_detail/widgets/interval_bar_chart.dart';
 import 'package:dawnbreaker/ui/common/components/app_badge.dart';
 import 'package:dawnbreaker/ui/common/components/app_button.dart';
 import 'package:dawnbreaker/ui/common/components/app_icon_button.dart';
-import 'package:dawnbreaker/ui/common/components/app_list_cell.dart';
 import 'package:dawnbreaker/ui/common/components/app_section_header.dart';
 import 'package:dawnbreaker/ui/common/components/app_task_icon_tile.dart';
 import 'package:dawnbreaker/ui/common/messages_mixin.dart';
@@ -43,105 +42,148 @@ class _AppDetailScreenState extends ConsumerState<AppDetailScreen>
 
     final uiState = ref.watch(provider);
     final viewModel = ref.read(provider.notifier);
-
-    final colors = context.appColorScheme;
     final task = uiState.task;
     final historyStats = uiState.historyStats;
-    final historyAndInterval = historyStats?.historyAndInterval ?? [];
 
     return Scaffold(
-      backgroundColor: colors.bg,
-      bottomNavigationBar: _RecordExecutionBar(
-        tintColor: task?.color ?? TaskColor.none,
-        onTap: () {
-          if (task == null) return;
-          TaskCompleteSheet.show(
-            context,
-            task: task,
-            onConfirm: (date, comment) =>
-                viewModel.recordExecution(task, date, comment),
-          );
-        },
-      ),
+      backgroundColor: context.appColorScheme.bg,
       body: CustomScrollView(
         slivers: [
-          SliverAppBar(
-            pinned: true,
-            surfaceTintColor: Colors.transparent,
-            scrolledUnderElevation: 3.0,
-            shadowColor: colors.shadow.withValues(alpha: 0.2),
-            automaticallyImplyLeading: false,
-            leading: Padding(
-              padding: const EdgeInsets.fromLTRB(8, 4, 0, 4),
-              child: AppIconButton(
-                icon: Icons.arrow_back_ios_new,
-                onTap: () => context.pop(),
-              ),
+          _buildAppBar(task, viewModel),
+          if (!uiState.isLoading && task != null && historyStats != null)
+            ..._buildContentAreas(
+              task,
+              historyStats,
+              uiState.daysSinceLastExecution,
+              uiState.averageIntervalDays,
+              viewModel,
             ),
-            title: Text(context.l10n.appDetailTitle),
-            actions: task != null
-                ? [
-                    AppIconButton(
-                      icon: Icons.edit_outlined,
-                      label: context.l10n.appDetailEdit,
-                      onTap: () =>
-                          context.push('/app-detail/${widget.taskId}/edit'),
-                    ),
-                    AppIconButton(
-                      icon: Icons.delete,
-                      label: context.l10n.appDetailDelete,
-                      tone: AppIconTone.destruction,
-                      onTap: viewModel.showDeleteTaskDialog,
-                    ),
-                    const SizedBox(width: 12),
-                  ]
-                : null,
-            bottom: task != null
-                ? PreferredSize(
-                    preferredSize: const Size.fromHeight(76),
-                    child: _TaskHeader(task: task),
-                  )
-                : null,
-          ),
-          if (!uiState.isLoading && task != null && historyStats != null) ...[
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.all(20),
-                child: _StatsAndChartCard(
-                  taskColor: task.color,
-                  daysSinceLastExecution: uiState.daysSinceLastExecution,
-                  averageIntervalDays: uiState.averageIntervalDays,
-                  historyStats: historyStats,
-                ),
-              ),
-            ),
-            SliverToBoxAdapter(
-              child: AppSectionHeader(
-                title: Text(context.l10n.appDetailHistorySection.toUpperCase()),
-                subTitle: Text(historyAndInterval.length.toString()),
-              ),
-            ),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
-              sliver: SliverList.builder(
-                itemCount: historyAndInterval.length,
-                itemBuilder: (context, i) {
-                  final (entry, intervalDays) = historyAndInterval[i];
-                  return _HistoryItem(
-                    entry: entry,
-                    isFirst: i == 0,
-                    isLast: i == historyAndInterval.length - 1,
-                    taskColor: task.color,
-                    intervalDays: intervalDays,
-                    onTap: () => _showEditSheet(task, entry),
-                  );
-                },
-              ),
-            ),
-            const SliverPadding(padding: EdgeInsets.only(bottom: 20)),
-          ],
         ],
       ),
+      bottomNavigationBar: task != null
+          ? _RecordExecutionBar(
+              tintColor: task.color,
+              onTap: () => TaskCompleteSheet.show(
+                context,
+                task: task,
+                onConfirm: (date, comment) =>
+                    viewModel.recordExecution(task, date, comment),
+              ),
+            )
+          : null,
+    );
+  }
+
+  Widget _buildAppBar(TaskItem? task, AppDetailViewModel viewModel) {
+    final colors = context.appColorScheme;
+    return SliverAppBar(
+      pinned: true,
+      surfaceTintColor: Colors.transparent,
+      scrolledUnderElevation: 3.0,
+      shadowColor: colors.shadow.withValues(alpha: 0.2),
+      automaticallyImplyLeading: false,
+      leading: Padding(
+        padding: const EdgeInsets.fromLTRB(8, 4, 0, 4),
+        child: AppIconButton(
+          icon: Icons.arrow_back_ios_new,
+          onTap: () => context.pop(),
+        ),
+      ),
+      title: Text(context.l10n.appDetailTitle),
+      actions: task != null
+          ? [
+              AppIconButton(
+                icon: Icons.edit_outlined,
+                label: context.l10n.appDetailEdit,
+                onTap: () => context.push('/app-detail/${widget.taskId}/edit'),
+              ),
+              AppIconButton(
+                icon: Icons.delete,
+                label: context.l10n.appDetailDelete,
+                tone: AppIconTone.destruction,
+                onTap: viewModel.showDeleteTaskDialog,
+              ),
+              const SizedBox(width: 12),
+            ]
+          : null,
+      bottom: task != null
+          ? PreferredSize(
+              preferredSize: const Size.fromHeight(76),
+              child: _TaskHeader(task: task),
+            )
+          : null,
+    );
+  }
+
+  List<Widget> _buildContentAreas(
+    TaskItem task,
+    TaskHistoryStats historyStats,
+    int? daysSinceLastExecution,
+    int? averageIntervalDays,
+    AppDetailViewModel viewModel,
+  ) {
+    return [
+      _statsArea(
+        task,
+        historyStats,
+        daysSinceLastExecution,
+        averageIntervalDays,
+      ),
+      _historyArea(task, historyStats.historyAndInterval, viewModel),
+      const SliverPadding(padding: EdgeInsets.only(bottom: 20)),
+    ];
+  }
+
+  Widget _statsArea(
+    TaskItem task,
+    TaskHistoryStats historyStats,
+    int? daysSinceLastExecution,
+    int? averageIntervalDays,
+  ) {
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: _StatsAndChartCard(
+          taskColor: task.color,
+          daysSinceLastExecution: daysSinceLastExecution,
+          averageIntervalDays: averageIntervalDays,
+          historyStats: historyStats,
+        ),
+      ),
+    );
+  }
+
+  Widget _historyArea(
+    TaskItem task,
+    List<(TaskHistory, int?)> historyAndInterval,
+    AppDetailViewModel viewModel,
+  ) {
+    return SliverMainAxisGroup(
+      slivers: [
+        SliverToBoxAdapter(
+          child: AppSectionHeader(
+            title: Text(context.l10n.appDetailHistorySection.toUpperCase()),
+            subTitle: Text(historyAndInterval.length.toString()),
+          ),
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          sliver: SliverList.builder(
+            itemCount: historyAndInterval.length,
+            itemBuilder: (context, i) {
+              final (entry, intervalDays) = historyAndInterval[i];
+              return AppDetailHistoryItem(
+                entry: entry,
+                isFirst: i == 0,
+                isLast: i == historyAndInterval.length - 1,
+                taskColor: task.color,
+                intervalDays: intervalDays,
+                onTap: () => _showEditSheet(task, entry),
+              );
+            },
+          ),
+        ),
+      ],
     );
   }
 
@@ -364,143 +406,6 @@ class _RecordExecutionBar extends StatelessWidget {
         fullWidth: true,
         size: AppButtonSize.large,
         tintColor: tintColor,
-      ),
-    );
-  }
-}
-
-class _HistoryItem extends StatelessWidget {
-  const _HistoryItem({
-    required this.entry,
-    required this.isFirst,
-    required this.isLast,
-    required this.taskColor,
-    required this.intervalDays,
-    this.onTap,
-  });
-
-  final TaskHistory entry;
-  final bool isFirst;
-  final bool isLast;
-  final TaskColor taskColor;
-  final int? intervalDays;
-  final VoidCallback? onTap;
-
-  static const _dotSize = 10.0;
-  static const _lineWidth = 1.5;
-  static const _paddingH = 20.0;
-  static const _paddingV = 14.0;
-  static const _dotTopY = _paddingV + 4.0;
-  static const _dotBottomY = _dotTopY + _dotSize;
-  static const _lineLeft = _paddingH + _dotSize / 2 - _lineWidth / 2;
-
-  AppListCellType get _type => switch ((isFirst, isLast)) {
-    (true, true) => .single,
-    (true, false) => .top,
-    (false, true) => .bottom,
-    _ => .middle,
-  };
-
-  BoxDecoration _dotDecoration(Color dotColor, Color surface) => isFirst
-      ? BoxDecoration(color: dotColor, shape: BoxShape.circle)
-      : BoxDecoration(
-          shape: BoxShape.circle,
-          border: Border.all(color: dotColor, width: _lineWidth),
-          color: surface,
-        );
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.appColorScheme;
-    final dotColor = taskColor.baseColor(context);
-
-    return AppListCell(
-      type: _type,
-      onTap: onTap,
-      child: Stack(
-        children: [
-          if (!isFirst || !isLast)
-            Positioned(
-              left: _lineLeft,
-              width: _lineWidth,
-              top: isFirst ? _dotBottomY : 0,
-              bottom: isLast ? null : 0,
-              height: isLast ? _dotTopY : null,
-              child: ColoredBox(color: colors.divider),
-            ),
-          Padding(
-            padding: EdgeInsets.fromLTRB(
-              _paddingH,
-              _paddingV,
-              _paddingH,
-              entry.comment == null ? _paddingV : 8,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Container(
-                      width: _dotSize,
-                      height: _dotSize,
-                      decoration: _dotDecoration(dotColor, colors.surface),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Text(
-                        DateUtil.format(context, entry.executedAt),
-                        style: AppTextStyle.body.copyWith(
-                          color: colors.text,
-                          fontWeight: isFirst
-                              ? FontWeight.w600
-                              : FontWeight.w400,
-                        ),
-                      ),
-                    ),
-                    if (intervalDays != null)
-                      Text(
-                        intervalDays! == 0
-                            ? context.l10n.commonToday
-                            : context.l10n.appDetailDaysInterval(intervalDays!),
-                        style: AppTextStyle.caption.copyWith(
-                          color: colors.textMuted,
-                        ),
-                      ),
-                  ],
-                ),
-                if (entry.comment case final comment?)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 8, left: _dotSize + 12),
-                    child: _HistoryComment(comment: comment),
-                  ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _HistoryComment extends StatelessWidget {
-  const _HistoryComment({required this.comment});
-
-  final String comment;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.appColorScheme;
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        border: Border.all(color: colors.border),
-        borderRadius: BorderRadius.circular(AppRadius.md),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        child: Text(
-          comment,
-          style: AppTextStyle.caption.copyWith(color: colors.textSubtle),
-        ),
       ),
     );
   }

--- a/lib/ui/app_detail/widgets/app_detail_screen.dart
+++ b/lib/ui/app_detail/widgets/app_detail_screen.dart
@@ -10,6 +10,7 @@ import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/ui/app_detail/viewmodel/app_detail_view_model.dart';
 import 'package:dawnbreaker/ui/app_detail/widgets/interval_bar_chart.dart';
 import 'package:dawnbreaker/ui/common/components/app_badge.dart';
+import 'package:dawnbreaker/ui/common/components/app_button.dart';
 import 'package:dawnbreaker/ui/common/components/app_icon_button.dart';
 import 'package:dawnbreaker/ui/common/components/app_list_cell.dart';
 import 'package:dawnbreaker/ui/common/components/app_section_header.dart';
@@ -47,10 +48,21 @@ class _AppDetailScreenState extends ConsumerState<AppDetailScreen>
     final task = uiState.task;
     final historyStats = uiState.historyStats;
     final historyAndInterval = historyStats?.historyAndInterval ?? [];
-    final bottomPadding = MediaQuery.paddingOf(context).bottom;
 
     return Scaffold(
       backgroundColor: colors.bg,
+      bottomNavigationBar: _RecordExecutionBar(
+        tintColor: task?.color ?? TaskColor.none,
+        onTap: () {
+          if (task == null) return;
+          TaskCompleteSheet.show(
+            context,
+            task: task,
+            onConfirm: (date, comment) =>
+                viewModel.recordExecution(task, date, comment),
+          );
+        },
+      ),
       body: CustomScrollView(
         slivers: [
           SliverAppBar(
@@ -126,7 +138,7 @@ class _AppDetailScreenState extends ConsumerState<AppDetailScreen>
                 },
               ),
             ),
-            SliverPadding(padding: EdgeInsets.only(bottom: 20 + bottomPadding)),
+            const SliverPadding(padding: EdgeInsets.only(bottom: 20)),
           ],
         ],
       ),
@@ -134,18 +146,14 @@ class _AppDetailScreenState extends ConsumerState<AppDetailScreen>
   }
 
   void _showEditSheet(TaskItem task, TaskHistory entry) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      isScrollControlled: true,
-      builder: (_) => TaskCompleteSheet(
-        task: task,
-        initialDate: entry.executedAt,
-        initialComment: entry.comment,
-        onConfirm: (date, comment) => ref
-            .read(appDetailViewModelProvider(taskId: widget.taskId).notifier)
-            .updateExecution(entry, executedAt: date, comment: comment),
-      ),
+    TaskCompleteSheet.show(
+      context,
+      task: task,
+      initialDate: entry.executedAt,
+      initialComment: entry.comment,
+      onConfirm: (date, comment) => ref
+          .read(appDetailViewModelProvider(taskId: widget.taskId).notifier)
+          .updateExecution(entry, executedAt: date, comment: comment),
     );
   }
 }
@@ -329,6 +337,33 @@ class _StatCell extends StatelessWidget {
               style: AppTextStyle.body.copyWith(color: colors.textMuted),
             ),
         ],
+      ),
+    );
+  }
+}
+
+class _RecordExecutionBar extends StatelessWidget {
+  const _RecordExecutionBar({required this.tintColor, required this.onTap});
+
+  final VoidCallback onTap;
+  final TaskColor tintColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.appColorScheme;
+    final bottomPadding = MediaQuery.paddingOf(context).bottom;
+    return Container(
+      padding: EdgeInsets.fromLTRB(16, 12, 16, 12 + bottomPadding),
+      decoration: BoxDecoration(
+        color: c.bg,
+        border: Border(top: BorderSide(color: c.divider)),
+      ),
+      child: AppButton(
+        label: context.l10n.appDetailRecordCompletion,
+        onPressed: onTap,
+        fullWidth: true,
+        size: AppButtonSize.large,
+        tintColor: tintColor,
       ),
     );
   }

--- a/lib/ui/common/components/app_button.dart
+++ b/lib/ui/common/components/app_button.dart
@@ -1,6 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:dawnbreaker/data/model/task_color.dart';
 import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
@@ -18,6 +19,7 @@ class AppButton extends StatelessWidget {
     this.size = AppButtonSize.medium,
     this.leading,
     this.fullWidth = false,
+    this.tintColor,
   });
 
   final String label;
@@ -26,6 +28,7 @@ class AppButton extends StatelessWidget {
   final AppButtonSize size;
   final Widget? leading;
   final bool fullWidth;
+  final TaskColor? tintColor;
 
   (double, EdgeInsets, TextStyle) get _sizeConfig => switch (size) {
     AppButtonSize.small => (
@@ -66,7 +69,21 @@ class AppButton extends StatelessWidget {
         : Text(label);
 
     return switch (variant) {
-      AppButtonVariant.primary => FilledButton(
+      .primary when tintColor is TaskColor => FilledButton(
+        onPressed: onPressed,
+        style: FilledButton.styleFrom(
+          backgroundColor: tintColor!.baseColor(context),
+          foregroundColor: c.primaryOn,
+          minimumSize: minSize,
+          padding: padding,
+          shape: shape,
+          textStyle: ts,
+          elevation: 1,
+          shadowColor: c.shadow,
+        ),
+        child: child,
+      ),
+      .primary => FilledButton(
         onPressed: onPressed,
         style: FilledButton.styleFrom(
           backgroundColor: c.primary,
@@ -80,7 +97,7 @@ class AppButton extends StatelessWidget {
         ),
         child: child,
       ),
-      AppButtonVariant.secondary => OutlinedButton(
+      .secondary => OutlinedButton(
         onPressed: onPressed,
         style: OutlinedButton.styleFrom(
           foregroundColor: c.text,
@@ -92,7 +109,7 @@ class AppButton extends StatelessWidget {
         ),
         child: child,
       ),
-      AppButtonVariant.ghost => TextButton(
+      .ghost => TextButton(
         onPressed: onPressed,
         style: TextButton.styleFrom(
           foregroundColor: c.text,
@@ -103,7 +120,7 @@ class AppButton extends StatelessWidget {
         ),
         child: child,
       ),
-      AppButtonVariant.danger => FilledButton(
+      .danger => FilledButton(
         onPressed: onPressed,
         style: FilledButton.styleFrom(
           backgroundColor: c.danger,
@@ -158,6 +175,49 @@ final class ButtonShowCase extends StatelessWidget {
                   label: 'Danger',
                   variant: AppButtonVariant.danger,
                   onPressed: () {},
+                ),
+              ],
+            ),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              spacing: 8,
+              children: [
+                AppButton(
+                  label: 'Tint',
+                  variant: AppButtonVariant.primary,
+                  onPressed: () {},
+                  tintColor: TaskColor.red,
+                ),
+                AppButton(
+                  label: 'Tint',
+                  variant: AppButtonVariant.primary,
+                  onPressed: () {},
+                  tintColor: TaskColor.blue,
+                ),
+                AppButton(
+                  label: 'Tint',
+                  variant: AppButtonVariant.primary,
+                  onPressed: () {},
+                  tintColor: TaskColor.orange,
+                ),
+                AppButton(
+                  label: 'Tint',
+                  variant: AppButtonVariant.primary,
+                  onPressed: () {},
+                  tintColor: TaskColor.yellow,
+                ),
+                AppButton(
+                  label: 'Tint',
+                  variant: AppButtonVariant.primary,
+                  onPressed: () {},
+                  tintColor: TaskColor.green,
+                ),
+                AppButton(
+                  label: 'Tint',
+                  variant: AppButtonVariant.primary,
+                  onPressed: () {},
+                  tintColor: TaskColor.none,
                 ),
               ],
             ),

--- a/lib/ui/common/components/app_icon_button.dart
+++ b/lib/ui/common/components/app_icon_button.dart
@@ -62,6 +62,10 @@ class AppIconButton extends StatelessWidget {
               color: buttonColor,
               fontWeight: FontWeight.w700,
             ),
+            strutStyle: StrutStyle(
+              fontSize: AppTextStyle.caption.fontSize,
+              height: 1.3,
+            ),
           ),
         ],
       );

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -85,7 +85,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
               onFilterChanged: viewModel.updateFilter,
             ),
           ),
-          ..._buildContentSlivers(context, uiState.hasTasks, taskList),
+          ..._buildContentSlivers(
+            context,
+            uiState.hasTasks,
+            taskList,
+            viewModel,
+          ),
           SliverPadding(
             padding: EdgeInsets.only(
               bottom: 8 + MediaQuery.paddingOf(context).bottom,
@@ -96,24 +101,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     );
   }
 
-  void _showCompleteSheet(BuildContext context, TaskItem task) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      isScrollControlled: true,
-      builder: (_) => TaskCompleteSheet(
-        task: task,
-        onConfirm: (date, comment) => ref
-            .read(homeViewModelProvider.notifier)
-            .recordExecution(task, date, comment),
-      ),
-    );
-  }
-
   List<Widget> _buildContentSlivers(
     BuildContext context,
     bool hasTasks,
     HomeTaskList taskList,
+    HomeViewModel viewModel,
   ) {
     if (taskList.isEmpty) {
       final colors = context.appColorScheme;
@@ -141,6 +133,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           context,
           entry.key,
           entry.value,
+          viewModel,
           addTopPadding: index > 0,
         ),
     ];
@@ -149,7 +142,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
   Widget _buildSectionSliver(
     BuildContext context,
     HomeTaskListType type,
-    List<TaskItem> tasks, {
+    List<TaskItem> tasks,
+    HomeViewModel viewModel, {
     required bool addTopPadding,
   }) {
     final colors = context.appColorScheme;
@@ -179,7 +173,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                   child: AppTaskListItem(
                     task: item,
                     onTap: () => context.push('/app-detail/${item.id}'),
-                    onComplete: () => _showCompleteSheet(context, item),
+                    onComplete: () => TaskCompleteSheet.show(
+                      context,
+                      task: item,
+                      onConfirm: (date, comment) =>
+                          viewModel.recordExecution(item, date, comment),
+                    ),
                   ),
                 ),
           ),

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -210,10 +210,12 @@ class _HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
       actions: [
         AppIconButton(
           onTap: () => context.push('/home/new_task'),
+          label: context.l10n.homeBarAdd,
           icon: Icons.add,
         ),
         AppIconButton(
           onTap: () => context.push('/settings'),
+          label: context.l10n.homeBarSettings,
           icon: Icons.settings_outlined,
         ),
       ],

--- a/lib/ui/home/widgets/task_complete_sheet.dart
+++ b/lib/ui/home/widgets/task_complete_sheet.dart
@@ -6,6 +6,7 @@ import 'package:dawnbreaker/core/util/date_util.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/ui/common/components/app_button.dart';
 import 'package:dawnbreaker/ui/common/components/app_input.dart';
+import 'package:dawnbreaker/ui/common/components/app_section_header.dart';
 import 'package:dawnbreaker/ui/common/components/app_task_icon_tile.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
@@ -51,25 +52,21 @@ class _TaskCompleteSheetState extends State<TaskCompleteSheet> {
   Widget build(BuildContext context) {
     final safeBottom = MediaQuery.paddingOf(context).bottom;
     final keyboardBottom = MediaQuery.viewInsetsOf(context).bottom;
+    final bottom = 16 + safeBottom + keyboardBottom;
 
     return SingleChildScrollView(
       child: Padding(
-        padding: EdgeInsets.fromLTRB(
-          20,
-          0,
-          20,
-          16 + safeBottom + keyboardBottom,
-        ),
+        padding: EdgeInsets.fromLTRB(20, 0, 20, bottom),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             _titleArea,
-            const SizedBox(height: 20),
-            _calendar,
             const SizedBox(height: 16),
-            _commentArea,
+            ..._calendarArea,
             const SizedBox(height: 16),
+            ..._commentArea,
+            const SizedBox(height: 24),
             _buttonArea,
           ],
         ),
@@ -104,33 +101,47 @@ class _TaskCompleteSheetState extends State<TaskCompleteSheet> {
     );
   }
 
-  Widget get _calendar {
+  List<Widget> get _calendarArea {
     final c = context.appColorScheme;
-    return Container(
-      height: 240,
-      clipBehavior: Clip.antiAlias,
-      decoration: BoxDecoration(
-        color: c.bgSubtle,
-        borderRadius: BorderRadius.circular(AppRadius.md),
-        border: Border.all(color: c.border),
+    return [
+      AppSectionHeader(
+        title: Text(context.l10n.homeCompleteDateLabel),
+        padding: const EdgeInsets.symmetric(vertical: 8),
       ),
-      child: CupertinoDatePicker(
-        mode: CupertinoDatePickerMode.date,
-        initialDateTime: _selectedDate,
-        minimumDate: DateTime(2000),
-        maximumDate: DateTime.now(),
-        onDateTimeChanged: (date) {
-          HapticFeedback.selectionClick();
-          setState(() => _selectedDate = date);
-        },
+      Container(
+        height: 200,
+        clipBehavior: Clip.antiAlias,
+        decoration: BoxDecoration(
+          color: c.bgSubtle,
+          borderRadius: BorderRadius.circular(AppRadius.md),
+          border: Border.all(color: c.border),
+        ),
+        child: CupertinoDatePicker(
+          mode: CupertinoDatePickerMode.date,
+          initialDateTime: _selectedDate,
+          minimumDate: DateTime(2000),
+          maximumDate: DateTime.now(),
+          onDateTimeChanged: (date) {
+            HapticFeedback.selectionClick();
+            setState(() => _selectedDate = date);
+          },
+        ),
       ),
-    );
+    ];
   }
 
-  Widget get _commentArea => AppTextInput(
-    controller: _commentController,
-    hintText: context.l10n.homeCompleteCommentPlaceholder,
-  );
+  List<Widget> get _commentArea {
+    return [
+      AppSectionHeader(
+        title: Text(context.l10n.homeCompleteCommentLabel),
+        padding: const EdgeInsets.symmetric(vertical: 8),
+      ),
+      AppTextInput(
+        controller: _commentController,
+        hintText: context.l10n.homeCompleteCommentPlaceholder,
+      ),
+    ];
+  }
 
   Widget get _buttonArea {
     return Row(

--- a/lib/ui/home/widgets/task_complete_sheet.dart
+++ b/lib/ui/home/widgets/task_complete_sheet.dart
@@ -9,6 +9,7 @@ import 'package:dawnbreaker/ui/common/components/app_input.dart';
 import 'package:dawnbreaker/ui/common/components/app_section_header.dart';
 import 'package:dawnbreaker/ui/common/components/app_task_icon_tile.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class TaskCompleteSheet extends StatefulWidget {
@@ -24,6 +25,24 @@ class TaskCompleteSheet extends StatefulWidget {
   final void Function(DateTime date, String? comment) onConfirm;
   final DateTime? initialDate;
   final String? initialComment;
+
+  static Future<void> show(
+    BuildContext context, {
+    required TaskItem task,
+    required void Function(DateTime date, String? comment) onConfirm,
+    DateTime? initialDate,
+    String? initialComment,
+  }) => showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    isScrollControlled: true,
+    builder: (_) => TaskCompleteSheet(
+      task: task,
+      onConfirm: onConfirm,
+      initialDate: initialDate,
+      initialComment: initialComment,
+    ),
+  );
 
   @override
   State<TaskCompleteSheet> createState() => _TaskCompleteSheetState();
@@ -170,6 +189,7 @@ class _TaskCompleteSheetState extends State<TaskCompleteSheet> {
               final comment = _commentController.text.trim();
               widget.onConfirm(_selectedDate, comment.isEmpty ? null : comment);
             },
+            tintColor: widget.task.color,
           ),
         ),
       ],

--- a/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
+++ b/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
@@ -388,6 +388,166 @@ void main() {
         });
       });
 
+      group('recordExecution', () {
+        group('正常系', () {
+          setUp(() async {
+            setUpContainer();
+            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+          });
+
+          test('成功時はエラーなし', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
+
+            expect(
+              container
+                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                  .dialogMessage,
+              isNull,
+            );
+          });
+
+          test('成功時に実行完了の通知がセットされる', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
+
+            final msg = container
+                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                .snackBarMessage;
+            expect(msg, isA<TaskCompleteSuccess>());
+            expect((msg as TaskCompleteSuccess).taskName, _taskOneHistory.name);
+          });
+
+          test('成功時の通知に undo ハンドラがある', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
+
+            final msg = container
+                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                .snackBarMessage;
+            expect(msg?.handler, isNotNull);
+          });
+
+          test('undo ハンドラを呼び出してもエラーが発生しない', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
+
+            final handler = container
+                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                .snackBarMessage
+                ?.handler;
+            expect(handler, isNotNull);
+            await handler!();
+
+            expect(
+              container
+                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                  .dialogMessage,
+              isNull,
+            );
+          });
+
+          for (final (comment, expectedComment, description) in [
+            (null, null, 'コメントなし'),
+            ('良い感じ', '良い感じ', 'コメントあり'),
+          ]) {
+            test('$descriptionで記録するとリポジトリにコメントが渡される', () async {
+              await container
+                  .read(
+                    appDetailViewModelProvider(
+                      taskId: _taskOneHistory.id,
+                    ).notifier,
+                  )
+                  .recordExecution(
+                    _taskOneHistory,
+                    DateTime(2026, 4, 1),
+                    comment,
+                  );
+
+              expect(fakeRepository.lastRecordedComment, expectedComment);
+              expect(
+                container
+                    .read(
+                      appDetailViewModelProvider(taskId: _taskOneHistory.id),
+                    )
+                    .snackBarMessage,
+                isA<TaskCompleteSuccess>(),
+              );
+            });
+          }
+        });
+
+        group('異常系', () {
+          setUp(() async {
+            fakeRepository = FakeTaskRepository(
+              initialTasks: _testTasks,
+              shouldThrow: true,
+            );
+            container = ProviderContainer(
+              overrides: [
+                taskRepositoryProvider.overrideWith((_) => fakeRepository),
+              ],
+            );
+            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+          });
+
+          test('リポジトリがエラーを返すと dialogMessage がセットされる', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
+
+            expect(
+              container
+                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                  .dialogMessage,
+              isA<TaskSaveErrorMessage>(),
+            );
+          });
+
+          test('失敗時に再試行できる', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
+
+            expect(
+              container
+                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                  .dialogMessage
+                  ?.handler,
+              isNotNull,
+            );
+          });
+        });
+      });
+
       group('showDeleteTaskDialog', () {
         setUp(() async {
           setUpContainer();


### PR DESCRIPTION
## Summary

- ホーム画面のアプリバーボタン（追加・設定）にラベルを追加し
- 完了シートにセクションヘッダを追加
- タスク詳細画面に「タスクの完了を登録する」ボタンを追加
- `app_detail_screen.dart` のリファクタリング：

## Test plan

- [x] `fvm flutter test` が全件パスすること
- [x] ホーム画面の右上ボタンにラベルが表示されること
- [x] 完了シートのセクションヘッダ（完了日・コメント）が表示されること
- [x] タスク詳細画面で「タスクの完了を登録する」ボタンから完了を記録できること
- [x] 完了後に undo スナックバーが表示され、取り消しできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)