### PR TITLE
履歴の長押し削除を追加

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -143,7 +143,7 @@
   },
   "appDetailRecordCompletion": "Record task completion",
   "appDetailUpdateHistorySuccess": "History updated",
-  "appDetailTaskDeleteConfirm": "Delete task “{name}”?",
+  "appDetailTaskDeleteConfirm": "Delete task \"{name}\"?",
   "@appDetailTaskDeleteConfirm": {
     "placeholders": {
       "name": {
@@ -151,6 +151,9 @@
       }
     }
   },
+  "appDetailDeleteHistorySuccess": "Completion record deleted",
+  "appDetailDeleteHistoryFailed": "Failed to delete record",
+  "appDetailDeleteHistoryButton": "Hold to delete",
   "onboardingPage1Title": "Never forget \"when was I supposed to do this?\"",
   "onboardingPage1Body": "Car wash, filter cleaning, toothbrush replacement... just register things you tend to forget.",
   "onboardingPage2Title": "Never wonder \"when should I do this next?\"",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -151,6 +151,9 @@
       }
     }
   },
+  "appDetailDeleteHistorySuccess": "完了記録を削除しました",
+  "appDetailDeleteHistoryFailed": "記録を削除できませんでした",
+  "appDetailDeleteHistoryButton": "長押しで削除",
   "onboardingPage1Title": "いつやるんだっけ？　の悩みをなくす",
   "onboardingPage1Body": "洗車、フィルター掃除、歯ブラシ交換……いつやるか忘れがちなことを登録しておくだけです。",
   "onboardingPage2Title": "次はいつごろだっけ？　の悩みをなくす",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -548,6 +548,24 @@ abstract class AppLocalizations {
   /// **'タスク「{name}」を削除しますか？'**
   String appDetailTaskDeleteConfirm(String name);
 
+  /// No description provided for @appDetailDeleteHistorySuccess.
+  ///
+  /// In ja, this message translates to:
+  /// **'完了記録を削除しました'**
+  String get appDetailDeleteHistorySuccess;
+
+  /// No description provided for @appDetailDeleteHistoryFailed.
+  ///
+  /// In ja, this message translates to:
+  /// **'記録を削除できませんでした'**
+  String get appDetailDeleteHistoryFailed;
+
+  /// No description provided for @appDetailDeleteHistoryButton.
+  ///
+  /// In ja, this message translates to:
+  /// **'長押しで削除'**
+  String get appDetailDeleteHistoryButton;
+
   /// No description provided for @onboardingPage1Title.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -251,8 +251,17 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String appDetailTaskDeleteConfirm(String name) {
-    return 'Delete task “$name”?';
+    return 'Delete task \"$name\"?';
   }
+
+  @override
+  String get appDetailDeleteHistorySuccess => 'Completion record deleted';
+
+  @override
+  String get appDetailDeleteHistoryFailed => 'Failed to delete record';
+
+  @override
+  String get appDetailDeleteHistoryButton => 'Hold to delete';
 
   @override
   String get onboardingPage1Title =>

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -254,6 +254,15 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get appDetailDeleteHistorySuccess => '完了記録を削除しました';
+
+  @override
+  String get appDetailDeleteHistoryFailed => '記録を削除できませんでした';
+
+  @override
+  String get appDetailDeleteHistoryButton => '長押しで削除';
+
+  @override
   String get onboardingPage1Title => 'いつやるんだっけ？　の悩みをなくす';
 
   @override

--- a/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
+++ b/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
@@ -139,4 +139,27 @@ class AppDetailViewModel extends _$AppDetailViewModel {
       );
     }
   }
+
+  Future<void> deleteExecution(TaskItem task, TaskHistory history) async {
+    try {
+      await _repository.deleteExecution(history.id);
+      if (!ref.mounted) return;
+      state = state.copyWith(
+        snackBarMessage: TaskExecutionDeleteSuccess(
+          handler: () => _repository.recordExecution(
+            task.id,
+            executedAt: history.executedAt,
+            comment: history.comment,
+          ),
+        ),
+      );
+    } on TaskRepositoryException {
+      if (!ref.mounted) return;
+      state = state.copyWith(
+        dialogMessage: TaskExecutionDeleteErrorMessage(
+          handler: () => deleteExecution(task, history),
+        ),
+      );
+    }
+  }
 }

--- a/lib/ui/app_detail/widgets/app_detail_screen.dart
+++ b/lib/ui/app_detail/widgets/app_detail_screen.dart
@@ -178,7 +178,7 @@ class _AppDetailScreenState extends ConsumerState<AppDetailScreen>
                 isLast: i == historyAndInterval.length - 1,
                 taskColor: task.color,
                 intervalDays: intervalDays,
-                onTap: () => _showEditSheet(task, entry),
+                onTap: () => _showEditSheet(task, entry, viewModel),
               );
             },
           ),
@@ -187,15 +187,19 @@ class _AppDetailScreenState extends ConsumerState<AppDetailScreen>
     );
   }
 
-  void _showEditSheet(TaskItem task, TaskHistory entry) {
+  void _showEditSheet(
+    TaskItem task,
+    TaskHistory entry,
+    AppDetailViewModel viewModel,
+  ) {
     TaskCompleteSheet.show(
       context,
       task: task,
       initialDate: entry.executedAt,
       initialComment: entry.comment,
-      onConfirm: (date, comment) => ref
-          .read(appDetailViewModelProvider(taskId: widget.taskId).notifier)
-          .updateExecution(entry, executedAt: date, comment: comment),
+      onConfirm: (date, comment) =>
+          viewModel.updateExecution(entry, executedAt: date, comment: comment),
+      onDelete: () => viewModel.deleteExecution(task, entry),
     );
   }
 }

--- a/lib/ui/common/components/app_app_bar.dart
+++ b/lib/ui/common/components/app_app_bar.dart
@@ -46,43 +46,38 @@ class AppAppBar extends StatelessWidget implements PreferredSizeWidget {
 @Preview()
 Widget previewAppAppBar() => const AppAppBarShowCase();
 
-final class AppAppBarShowCase extends StatelessWidget {
+final class AppAppBarShowCase extends PreviewShowCase {
   const AppAppBarShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget buildPreview(BuildContext context) {
     final c = context.appColorScheme;
-    return PreviewWrapper(
-      child: ColoredBox(
-        color: c.bg,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const AppAppBar(title: 'タイトルのみ'),
-            Divider(height: 1, color: c.divider),
-            AppAppBar(
-              title: 'アクションあり',
-              actions: [
-                AppIconButton(onTap: () {}, icon: Icons.add),
-                const SizedBox(width: 8),
-                AppIconButton(onTap: () {}, icon: Icons.settings_outlined),
-                const SizedBox(width: 4),
-              ],
-            ),
-            Divider(height: 1, color: c.divider),
-            AppAppBar(title: '戻るボタンあり', onBack: () {}),
-            Divider(height: 1, color: c.divider),
-            AppAppBar(
-              title: 'すべてあり',
-              onBack: () {},
-              actions: [
-                AppIconButton(onTap: () {}, icon: Icons.more_vert),
-                const SizedBox(width: 4),
-              ],
-            ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const AppAppBar(title: 'タイトルのみ'),
+        Divider(height: 1, color: c.divider),
+        AppAppBar(
+          title: 'アクションあり',
+          actions: [
+            AppIconButton(onTap: () {}, icon: Icons.add),
+            const SizedBox(width: 8),
+            AppIconButton(onTap: () {}, icon: Icons.settings_outlined),
+            const SizedBox(width: 4),
           ],
         ),
-      ),
+        Divider(height: 1, color: c.divider),
+        AppAppBar(title: '戻るボタンあり', onBack: () {}),
+        Divider(height: 1, color: c.divider),
+        AppAppBar(
+          title: 'すべてあり',
+          onBack: () {},
+          actions: [
+            AppIconButton(onTap: () {}, icon: Icons.more_vert),
+            const SizedBox(width: 4),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/ui/common/components/app_app_bar.dart
+++ b/lib/ui/common/components/app_app_bar.dart
@@ -1,6 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/ui/common/components/app_icon_button.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 

--- a/lib/ui/common/components/app_badge.dart
+++ b/lib/ui/common/components/app_badge.dart
@@ -1,7 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 

--- a/lib/ui/common/components/app_badge.dart
+++ b/lib/ui/common/components/app_badge.dart
@@ -56,30 +56,20 @@ class AppBadge extends StatelessWidget {
 @Preview()
 Widget previewAllTones() => const LabelShowCase();
 
-final class LabelShowCase extends StatelessWidget {
+final class LabelShowCase extends PreviewShowCase {
   const LabelShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final colorScheme = context.appColorScheme;
-    return PreviewWrapper(
-      child: Container(
-        color: colorScheme.bg,
-        padding: const EdgeInsets.all(18),
-        alignment: Alignment.center,
-        child: const Row(
-          spacing: 6,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            AppBadge(label: '中立', tone: AppBadgeTone.neutral),
-            AppBadge(label: '11日超過', tone: AppBadgeTone.danger),
-            AppBadge(label: '今日', tone: AppBadgeTone.warning),
-            AppBadge(label: '完了', tone: AppBadgeTone.success),
-            AppBadge(label: '情報', tone: AppBadgeTone.info),
-            AppBadge(label: '残り6日', tone: AppBadgeTone.primary),
-          ],
-        ),
-      ),
-    );
-  }
+  Widget buildPreview(BuildContext context) => const Row(
+    spacing: 6,
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppBadge(label: '中立', tone: AppBadgeTone.neutral),
+      AppBadge(label: '11日超過', tone: AppBadgeTone.danger),
+      AppBadge(label: '今日', tone: AppBadgeTone.warning),
+      AppBadge(label: '完了', tone: AppBadgeTone.success),
+      AppBadge(label: '情報', tone: AppBadgeTone.info),
+      AppBadge(label: '残り6日', tone: AppBadgeTone.primary),
+    ],
+  );
 }

--- a/lib/ui/common/components/app_button.dart
+++ b/lib/ui/common/components/app_button.dart
@@ -141,124 +141,112 @@ class AppButton extends StatelessWidget {
 @Preview()
 Widget previewButton() => const ButtonShowCase();
 
-final class ButtonShowCase extends StatelessWidget {
+final class ButtonShowCase extends PreviewShowCase {
   const ButtonShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final c = context.appColorScheme;
-    return PreviewWrapper(
-      child: Container(
-        color: c.bg,
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          spacing: 16,
-          children: [
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              spacing: 8,
-              children: [
-                AppButton(label: 'Primary', onPressed: () {}),
-                AppButton(
-                  label: 'Secondary',
-                  variant: AppButtonVariant.secondary,
-                  onPressed: () {},
-                ),
-                AppButton(
-                  label: 'Ghost',
-                  variant: AppButtonVariant.ghost,
-                  onPressed: () {},
-                ),
-                AppButton(
-                  label: 'Danger',
-                  variant: AppButtonVariant.danger,
-                  onPressed: () {},
-                ),
-              ],
-            ),
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              spacing: 8,
-              children: [
-                AppButton(
-                  label: 'Tint',
-                  variant: AppButtonVariant.primary,
-                  onPressed: () {},
-                  tintColor: TaskColor.red,
-                ),
-                AppButton(
-                  label: 'Tint',
-                  variant: AppButtonVariant.primary,
-                  onPressed: () {},
-                  tintColor: TaskColor.blue,
-                ),
-                AppButton(
-                  label: 'Tint',
-                  variant: AppButtonVariant.primary,
-                  onPressed: () {},
-                  tintColor: TaskColor.orange,
-                ),
-                AppButton(
-                  label: 'Tint',
-                  variant: AppButtonVariant.primary,
-                  onPressed: () {},
-                  tintColor: TaskColor.yellow,
-                ),
-                AppButton(
-                  label: 'Tint',
-                  variant: AppButtonVariant.primary,
-                  onPressed: () {},
-                  tintColor: TaskColor.green,
-                ),
-                AppButton(
-                  label: 'Tint',
-                  variant: AppButtonVariant.primary,
-                  onPressed: () {},
-                  tintColor: TaskColor.none,
-                ),
-              ],
-            ),
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              spacing: 8,
-              children: [
-                AppButton(
-                  label: 'Small',
-                  size: AppButtonSize.small,
-                  onPressed: () {},
-                ),
-                AppButton(label: 'Medium', onPressed: () {}),
-                AppButton(
-                  label: 'Large',
-                  size: AppButtonSize.large,
-                  onPressed: () {},
-                ),
-              ],
-            ),
-            const Row(
-              mainAxisSize: MainAxisSize.min,
-              spacing: 8,
-              children: [
-                AppButton(label: 'Primary'),
-                AppButton(
-                  label: 'Secondary',
-                  variant: AppButtonVariant.secondary,
-                ),
-                AppButton(label: 'Danger', variant: AppButtonVariant.danger),
-              ],
-            ),
-            AppButton(
-              label: '完了',
-              onPressed: () {},
-              leading: const Icon(Icons.check, size: 16),
-            ),
-          ],
-        ),
+  Widget buildPreview(BuildContext context) => Column(
+    mainAxisSize: MainAxisSize.min,
+    crossAxisAlignment: CrossAxisAlignment.start,
+    spacing: 16,
+    children: [
+      Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 8,
+        children: [
+          AppButton(label: 'Primary', onPressed: () {}),
+          AppButton(
+            label: 'Secondary',
+            variant: AppButtonVariant.secondary,
+            onPressed: () {},
+          ),
+          AppButton(
+            label: 'Ghost',
+            variant: AppButtonVariant.ghost,
+            onPressed: () {},
+          ),
+          AppButton(
+            label: 'Danger',
+            variant: AppButtonVariant.danger,
+            onPressed: () {},
+          ),
+        ],
       ),
-    );
-  }
+      Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        spacing: 8,
+        children: [
+          AppButton(
+            label: 'Tint',
+            variant: AppButtonVariant.primary,
+            onPressed: () {},
+            tintColor: TaskColor.red,
+          ),
+          AppButton(
+            label: 'Tint',
+            variant: AppButtonVariant.primary,
+            onPressed: () {},
+            tintColor: TaskColor.blue,
+          ),
+          AppButton(
+            label: 'Tint',
+            variant: AppButtonVariant.primary,
+            onPressed: () {},
+            tintColor: TaskColor.orange,
+          ),
+          AppButton(
+            label: 'Tint',
+            variant: AppButtonVariant.primary,
+            onPressed: () {},
+            tintColor: TaskColor.yellow,
+          ),
+          AppButton(
+            label: 'Tint',
+            variant: AppButtonVariant.primary,
+            onPressed: () {},
+            tintColor: TaskColor.green,
+          ),
+          AppButton(
+            label: 'Tint',
+            variant: AppButtonVariant.primary,
+            onPressed: () {},
+            tintColor: TaskColor.none,
+          ),
+        ],
+      ),
+      Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        spacing: 8,
+        children: [
+          AppButton(
+            label: 'Small',
+            size: AppButtonSize.small,
+            onPressed: () {},
+          ),
+          AppButton(label: 'Medium', onPressed: () {}),
+          AppButton(
+            label: 'Large',
+            size: AppButtonSize.large,
+            onPressed: () {},
+          ),
+        ],
+      ),
+      const Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 8,
+        children: [
+          AppButton(label: 'Primary'),
+          AppButton(label: 'Secondary', variant: AppButtonVariant.secondary),
+          AppButton(label: 'Danger', variant: AppButtonVariant.danger),
+        ],
+      ),
+      AppButton(
+        label: '完了',
+        onPressed: () {},
+        leading: const Icon(Icons.check, size: 16),
+      ),
+    ],
+  );
 }

--- a/lib/ui/common/components/app_button.dart
+++ b/lib/ui/common/components/app_button.dart
@@ -2,7 +2,7 @@ import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
 import 'package:dawnbreaker/data/model/task_color.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 

--- a/lib/ui/common/components/app_button.dart
+++ b/lib/ui/common/components/app_button.dart
@@ -1,14 +1,14 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
-import 'package:dawnbreaker/app/app_typography.dart';
 import 'package:dawnbreaker/data/model/task_color.dart';
+import 'package:dawnbreaker/ui/common/components/app_button_size.dart';
 import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 
-enum AppButtonVariant { primary, secondary, ghost, danger }
+export 'package:dawnbreaker/ui/common/components/app_button_size.dart';
 
-enum AppButtonSize { small, medium, large }
+enum AppButtonVariant { primary, secondary, ghost, danger }
 
 class AppButton extends StatelessWidget {
   const AppButton({
@@ -30,28 +30,12 @@ class AppButton extends StatelessWidget {
   final bool fullWidth;
   final TaskColor? tintColor;
 
-  (double, EdgeInsets, TextStyle) get _sizeConfig => switch (size) {
-    AppButtonSize.small => (
-      32.0,
-      const EdgeInsets.symmetric(horizontal: 12),
-      AppTextStyle.caption,
-    ),
-    AppButtonSize.medium => (
-      40.0,
-      const EdgeInsets.symmetric(horizontal: 16),
-      AppTextStyle.body,
-    ),
-    AppButtonSize.large => (
-      52.0,
-      const EdgeInsets.symmetric(horizontal: 22),
-      AppTextStyle.headline,
-    ),
-  };
-
   @override
   Widget build(BuildContext context) {
     final c = context.appColorScheme;
-    final (height, padding, textStyle) = _sizeConfig;
+    final height = size.height;
+    final padding = size.padding;
+    final textStyle = size.textStyle;
     final minSize = Size(fullWidth ? double.infinity : 0, height);
     final shape = RoundedRectangleBorder(
       borderRadius: BorderRadius.circular(AppRadius.md),

--- a/lib/ui/common/components/app_button_size.dart
+++ b/lib/ui/common/components/app_button_size.dart
@@ -1,0 +1,14 @@
+import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:flutter/material.dart';
+
+enum AppButtonSize {
+  small(32.0, EdgeInsets.symmetric(horizontal: 12), AppTextStyle.caption),
+  medium(40.0, EdgeInsets.symmetric(horizontal: 16), AppTextStyle.body),
+  large(52.0, EdgeInsets.symmetric(horizontal: 22), AppTextStyle.headline);
+
+  const AppButtonSize(this.height, this.padding, this.textStyle);
+
+  final double height;
+  final EdgeInsets padding;
+  final TextStyle textStyle;
+}

--- a/lib/ui/common/components/app_dialog.dart
+++ b/lib/ui/common/components/app_dialog.dart
@@ -1,6 +1,6 @@
 import 'package:dawnbreaker/core/util/context_extension.dart';
 import 'package:dawnbreaker/ui/common/components/app_button.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:dawnbreaker/ui/common/dialog_message.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';

--- a/lib/ui/common/components/app_dialog.dart
+++ b/lib/ui/common/components/app_dialog.dart
@@ -67,6 +67,11 @@ class AppDialog extends StatelessWidget {
     messageText: context.l10n.taskErrorDeleteFailed,
     actionLabel: context.l10n.commonRetry,
   ),
+  TaskExecutionDeleteErrorMessage() => (
+    title: context.l10n.commonErrorTitle,
+    messageText: context.l10n.appDetailDeleteHistoryFailed,
+    actionLabel: context.l10n.commonRetry,
+  ),
   DeleteTaskConfirmMessage(:final taskName) => (
     title: context.l10n.commonConfirmTitle,
     messageText: context.l10n.appDetailTaskDeleteConfirm(taskName),

--- a/lib/ui/common/components/app_dialog.dart
+++ b/lib/ui/common/components/app_dialog.dart
@@ -1,4 +1,3 @@
-import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/core/util/context_extension.dart';
 import 'package:dawnbreaker/ui/common/components/app_button.dart';
 import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
@@ -139,71 +138,62 @@ List<Widget> _buildActions(
 @Preview()
 Widget previewAppDialog() => const DialogShowCase();
 
-final class DialogShowCase extends StatelessWidget {
+final class DialogShowCase extends PreviewShowCase {
   const DialogShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final c = context.appColorScheme;
-    return PreviewWrapper(
-      child: Container(
-        color: c.bg,
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          spacing: 24,
-          children: [
-            AppDialog(
-              title: 'エラー',
-              message: '読み込みに失敗しました。',
-              actions: [
-                AppButton(
-                  label: 'OK',
-                  variant: .secondary,
-                  size: .medium,
-                  onPressed: () {},
-                ),
-              ],
-            ),
-            AppDialog(
-              title: 'エラー',
-              message: '読み込みに失敗しました。',
-              actions: [
-                AppButton(
-                  label: 'キャンセル',
-                  variant: .secondary,
-                  size: .medium,
-                  onPressed: () {},
-                ),
-                AppButton(
-                  label: '再試行',
-                  variant: .primary,
-                  size: .medium,
-                  onPressed: () {},
-                ),
-              ],
-            ),
-            AppDialog(
-              title: '確認',
-              message: 'タスクを削除しますか？',
-              actions: [
-                AppButton(
-                  label: 'キャンセル',
-                  variant: .secondary,
-                  size: .medium,
-                  onPressed: () {},
-                ),
-                AppButton(
-                  label: '削除',
-                  variant: .danger,
-                  size: .medium,
-                  onPressed: () {},
-                ),
-              ],
-            ),
-          ],
-        ),
+  Widget buildPreview(BuildContext context) => Column(
+    mainAxisSize: MainAxisSize.min,
+    spacing: 24,
+    children: [
+      AppDialog(
+        title: 'エラー',
+        message: '読み込みに失敗しました。',
+        actions: [
+          AppButton(
+            label: 'OK',
+            variant: .secondary,
+            size: .medium,
+            onPressed: () {},
+          ),
+        ],
       ),
-    );
-  }
+      AppDialog(
+        title: 'エラー',
+        message: '読み込みに失敗しました。',
+        actions: [
+          AppButton(
+            label: 'キャンセル',
+            variant: .secondary,
+            size: .medium,
+            onPressed: () {},
+          ),
+          AppButton(
+            label: '再試行',
+            variant: .primary,
+            size: .medium,
+            onPressed: () {},
+          ),
+        ],
+      ),
+      AppDialog(
+        title: '確認',
+        message: 'タスクを削除しますか？',
+        actions: [
+          AppButton(
+            label: 'キャンセル',
+            variant: .secondary,
+            size: .medium,
+            onPressed: () {},
+          ),
+          AppButton(
+            label: '削除',
+            variant: .danger,
+            size: .medium,
+            onPressed: () {},
+          ),
+        ],
+      ),
+    ],
+  );
 }

--- a/lib/ui/common/components/app_filter_chip.dart
+++ b/lib/ui/common/components/app_filter_chip.dart
@@ -1,7 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 

--- a/lib/ui/common/components/app_filter_chip.dart
+++ b/lib/ui/common/components/app_filter_chip.dart
@@ -70,37 +70,18 @@ class AppFilterChip extends StatelessWidget {
 @Preview()
 Widget previewFilterChip() => const FilterChipShowCase();
 
-final class FilterChipShowCase extends StatelessWidget {
+final class FilterChipShowCase extends PreviewShowCase {
   const FilterChipShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final c = context.appColorScheme;
-    return PreviewWrapper(
-      child: Container(
-        color: c.bg,
-        padding: const EdgeInsets.all(24),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          spacing: 6,
-          children: [
-            AppFilterChip(
-              label: 'すべて',
-              isSelected: true,
-              onTap: () {},
-              count: 12,
-            ),
-            AppFilterChip(
-              label: '超過',
-              isSelected: false,
-              onTap: () {},
-              count: 3,
-            ),
-            AppFilterChip(label: '今日', isSelected: false, onTap: () {}),
-            AppFilterChip(label: '7日以内', isSelected: false, onTap: () {}),
-          ],
-        ),
-      ),
-    );
-  }
+  Widget buildPreview(BuildContext context) => Row(
+    mainAxisSize: MainAxisSize.min,
+    spacing: 6,
+    children: [
+      AppFilterChip(label: 'すべて', isSelected: true, onTap: () {}, count: 12),
+      AppFilterChip(label: '超過', isSelected: false, onTap: () {}, count: 3),
+      AppFilterChip(label: '今日', isSelected: false, onTap: () {}),
+      AppFilterChip(label: '7日以内', isSelected: false, onTap: () {}),
+    ],
+  );
 }

--- a/lib/ui/common/components/app_icon_button.dart
+++ b/lib/ui/common/components/app_icon_button.dart
@@ -93,26 +93,16 @@ extension _AppIconButtonTone on AppColorScheme {
 @Preview()
 Widget previewIconButton() => const IconButtonShowCase();
 
-final class IconButtonShowCase extends StatelessWidget {
+final class IconButtonShowCase extends PreviewShowCase {
   const IconButtonShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final colorScheme = context.appColorScheme;
-    return PreviewWrapper(
-      child: Container(
-        color: colorScheme.bg,
-        padding: const EdgeInsets.all(18),
-        alignment: Alignment.center,
-        child: Row(
-          spacing: 6,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            AppIconButton(icon: Icons.add_ic_call_outlined, onTap: () {}),
-            AppIconButton(icon: Icons.edit, label: '編集', onTap: () {}),
-          ],
-        ),
-      ),
-    );
-  }
+  Widget buildPreview(BuildContext context) => Row(
+    spacing: 6,
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppIconButton(icon: Icons.add_ic_call_outlined, onTap: () {}),
+      AppIconButton(icon: Icons.edit, label: '編集', onTap: () {}),
+    ],
+  );
 }

--- a/lib/ui/common/components/app_icon_button.dart
+++ b/lib/ui/common/components/app_icon_button.dart
@@ -1,7 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:dawnbreaker/ui/common/extend_hit_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';

--- a/lib/ui/common/components/app_input.dart
+++ b/lib/ui/common/components/app_input.dart
@@ -1,7 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 

--- a/lib/ui/common/components/app_input.dart
+++ b/lib/ui/common/components/app_input.dart
@@ -174,36 +174,21 @@ class _AppSearchInputState extends State<AppSearchInput> {
 @Preview()
 Widget previewInputs() => const InputShowCase();
 
-final class InputShowCase extends StatelessWidget {
+final class InputShowCase extends PreviewShowCase {
   const InputShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final c = context.appColorScheme;
-    return PreviewWrapper(
-      child: ColoredBox(
-        color: c.bg,
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: SizedBox(
-            width: 320,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              spacing: 16,
-              children: [
-                const AppTextInput(hintText: 'タスク名を入力'),
-                const AppSearchInput(placeholder: 'タスクを検索'),
-                AppSearchInput(
-                  placeholder: '検索中…',
-                  showClear: true,
-                  onClear: () {},
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
+  Widget buildPreview(BuildContext context) => const SizedBox(
+    width: 320,
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      spacing: 16,
+      children: [
+        AppTextInput(hintText: 'タスク名を入力'),
+        AppSearchInput(placeholder: 'タスクを検索'),
+        AppSearchInput(placeholder: '検索中…', showClear: true),
+      ],
+    ),
+  );
 }

--- a/lib/ui/common/components/app_list_cell.dart
+++ b/lib/ui/common/components/app_list_cell.dart
@@ -1,7 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
 import 'package:dawnbreaker/ui/common/components/app_section_header.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 

--- a/lib/ui/common/components/app_list_cell.dart
+++ b/lib/ui/common/components/app_list_cell.dart
@@ -92,11 +92,11 @@ class AppListCell extends StatelessWidget {
 @Preview()
 Widget previewAppListCell() => const AppListCellShowCase();
 
-final class AppListCellShowCase extends StatelessWidget {
+final class AppListCellShowCase extends PreviewShowCase {
   const AppListCellShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget buildPreview(BuildContext context) {
     final c = context.appColorScheme;
     Widget cell(AppListCellType type, String label) => AppListCell(
       type: type,
@@ -115,19 +115,14 @@ final class AppListCellShowCase extends StatelessWidget {
       cell(.middle, '3rd line'),
       cell(.bottom, '4th line'),
     ];
-    return PreviewWrapper(
-      child: Material(
-        color: c.bg,
-        child: Padding(
-          padding: const EdgeInsetsGeometry.all(10),
-          child: ListView.separated(
-            itemCount: items.length,
-            itemBuilder: (context, index) => items[index],
-            separatorBuilder: AppListCell.buildSeparator(
-              items,
-              borderColor: c.border,
-            ),
-          ),
+    return Material(
+      type: MaterialType.transparency,
+      child: ListView.separated(
+        itemCount: items.length,
+        itemBuilder: (_, index) => items[index],
+        separatorBuilder: AppListCell.buildSeparator(
+          items,
+          borderColor: c.border,
         ),
       ),
     );

--- a/lib/ui/common/components/app_long_press_button.dart
+++ b/lib/ui/common/components/app_long_press_button.dart
@@ -1,6 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
-import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:dawnbreaker/ui/common/components/app_button_size.dart';
 import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
@@ -11,11 +11,13 @@ class AppLongPressButton extends StatefulWidget {
     required this.label,
     this.onLongPress,
     this.duration = const Duration(milliseconds: 1000),
+    this.size = AppButtonSize.medium,
   });
 
   final String label;
   final VoidCallback? onLongPress;
   final Duration duration;
+  final AppButtonSize size;
 
   @override
   State<AppLongPressButton> createState() => _AppLongPressButtonState();
@@ -24,6 +26,7 @@ class AppLongPressButton extends StatefulWidget {
 class _AppLongPressButtonState extends State<AppLongPressButton>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
+  bool _isFinished = false;
 
   @override
   void initState() {
@@ -32,6 +35,7 @@ class _AppLongPressButtonState extends State<AppLongPressButton>
     _controller.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
         widget.onLongPress?.call();
+        _isFinished = true;
       }
     });
   }
@@ -50,10 +54,13 @@ class _AppLongPressButtonState extends State<AppLongPressButton>
     super.dispose();
   }
 
-  void _onTapDown(TapDownDetails _) => _controller.forward(from: 0);
+  void _onTapDown(TapDownDetails _) =>
+      _controller.forward(from: _controller.value);
 
   void _onEnd() {
-    _controller.animateTo(
+    if (_isFinished) return;
+
+    _controller.animateBack(
       0,
       duration: const Duration(milliseconds: 300),
       curve: Curves.easeOut,
@@ -63,6 +70,7 @@ class _AppLongPressButtonState extends State<AppLongPressButton>
   @override
   Widget build(BuildContext context) {
     final colors = context.appColorScheme;
+    final size = widget.size;
     final radius = BorderRadius.circular(AppRadius.md);
     return GestureDetector(
       onTapDown: _onTapDown,
@@ -89,13 +97,13 @@ class _AppLongPressButtonState extends State<AppLongPressButton>
                   ),
                 ),
                 ConstrainedBox(
-                  constraints: const BoxConstraints(minHeight: 48),
+                  constraints: BoxConstraints(minHeight: size.height),
                   child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    padding: size.padding,
                     child: Center(
                       child: Text(
                         widget.label,
-                        style: AppTextStyle.body.copyWith(
+                        style: size.textStyle.copyWith(
                           color: Color.lerp(
                             colors.danger,
                             colors.dangerSoft,

--- a/lib/ui/common/components/app_long_press_button.dart
+++ b/lib/ui/common/components/app_long_press_button.dart
@@ -1,0 +1,128 @@
+import 'package:dawnbreaker/app/app_colors.dart';
+import 'package:dawnbreaker/app/app_radius.dart';
+import 'package:dawnbreaker/app/app_typography.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widget_previews.dart';
+
+class AppLongPressButton extends StatefulWidget {
+  const AppLongPressButton({
+    super.key,
+    required this.label,
+    this.onLongPress,
+    this.duration = const Duration(milliseconds: 1000),
+  });
+
+  final String label;
+  final VoidCallback? onLongPress;
+  final Duration duration;
+
+  @override
+  State<AppLongPressButton> createState() => _AppLongPressButtonState();
+}
+
+class _AppLongPressButtonState extends State<AppLongPressButton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: widget.duration);
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onLongPress?.call();
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(AppLongPressButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.duration != widget.duration) {
+      _controller.duration = widget.duration;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onTapDown(TapDownDetails _) => _controller.forward(from: 0);
+
+  void _onEnd() {
+    _controller.animateTo(
+      0,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOut,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.appColorScheme;
+    final radius = BorderRadius.circular(AppRadius.md);
+    return GestureDetector(
+      onTapDown: _onTapDown,
+      onTapUp: (_) => _onEnd(),
+      onTapCancel: _onEnd,
+      child: DecoratedBox(
+        position: DecorationPosition.foreground,
+        decoration: BoxDecoration(
+          border: Border.all(color: colors.danger),
+          borderRadius: radius,
+        ),
+        child: ClipRRect(
+          borderRadius: radius,
+          child: AnimatedBuilder(
+            animation: _controller,
+            builder: (context, _) => Stack(
+              children: [
+                Positioned.fill(child: ColoredBox(color: colors.dangerSoft)),
+                Positioned.fill(
+                  child: FractionallySizedBox(
+                    alignment: Alignment.centerLeft,
+                    widthFactor: _controller.value,
+                    child: ColoredBox(color: colors.danger),
+                  ),
+                ),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 48),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Center(
+                      child: Text(
+                        widget.label,
+                        style: AppTextStyle.body.copyWith(
+                          color: Color.lerp(
+                            colors.danger,
+                            colors.dangerSoft,
+                            _controller.value,
+                          ),
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+@Preview()
+Widget previewLongPressButton() => const LongPressButtonShowCase();
+
+final class LongPressButtonShowCase extends PreviewShowCase {
+  const LongPressButtonShowCase({super.key});
+
+  @override
+  Widget buildPreview(BuildContext context) =>
+      const AppLongPressButton(label: '長押しで削除');
+}

--- a/lib/ui/common/components/app_pill_button.dart
+++ b/lib/ui/common/components/app_pill_button.dart
@@ -77,36 +77,27 @@ class AppPillButton extends StatelessWidget {
 @Preview()
 Widget previewPillButton() => const PillButtonShowCase();
 
-final class PillButtonShowCase extends StatelessWidget {
+final class PillButtonShowCase extends PreviewShowCase {
   const PillButtonShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final c = context.appColorScheme;
-    return PreviewWrapper(
-      child: Container(
-        color: c.bg,
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          spacing: 12,
-          children: [
-            AppPillButton(
-              label: '完了',
-              onPressed: () {},
-              leading: const Icon(Icons.check),
-            ),
-            AppPillButton(
-              label: '完了',
-              variant: AppPillButtonVariant.secondary,
-              onPressed: () {},
-              leading: const Icon(Icons.check),
-            ),
-            const AppPillButton(label: '完了 (disabled)'),
-          ],
-        ),
+  Widget buildPreview(BuildContext context) => Column(
+    mainAxisSize: MainAxisSize.min,
+    crossAxisAlignment: CrossAxisAlignment.start,
+    spacing: 12,
+    children: [
+      AppPillButton(
+        label: '完了',
+        onPressed: () {},
+        leading: const Icon(Icons.check),
       ),
-    );
-  }
+      AppPillButton(
+        label: '完了',
+        variant: AppPillButtonVariant.secondary,
+        onPressed: () {},
+        leading: const Icon(Icons.check),
+      ),
+      const AppPillButton(label: '完了 (disabled)'),
+    ],
+  );
 }

--- a/lib/ui/common/components/app_pill_button.dart
+++ b/lib/ui/common/components/app_pill_button.dart
@@ -1,7 +1,7 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
 import 'package:dawnbreaker/data/model/task_color.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 

--- a/lib/ui/common/components/app_progress_bar.dart
+++ b/lib/ui/common/components/app_progress_bar.dart
@@ -1,6 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 

--- a/lib/ui/common/components/app_progress_bar.dart
+++ b/lib/ui/common/components/app_progress_bar.dart
@@ -283,33 +283,24 @@ class _BlinkBarState extends State<_BlinkBar>
 @Preview()
 Widget previewProgressBar() => const ProgressBarShowCase();
 
-final class ProgressBarShowCase extends StatelessWidget {
+final class ProgressBarShowCase extends PreviewShowCase {
   const ProgressBarShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final c = context.appColorScheme;
-    return PreviewWrapper(
-      child: Container(
-        color: c.bg,
-        padding: const EdgeInsets.all(24),
-        child: const SizedBox(
-          width: 320,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            spacing: 16,
-            children: [
-              AppProgressBar(value: 0.15),
-              AppProgressBar(value: 0.25),
-              AppProgressBar(value: 0.55),
-              AppProgressBar(value: 0.85),
-              AppProgressBar(value: 1.0, isOverdue: false),
-              AppProgressBar(value: 1.0, isOverdue: true),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
+  Widget buildPreview(BuildContext context) => const SizedBox(
+    width: 320,
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      spacing: 16,
+      children: [
+        AppProgressBar(value: 0.15),
+        AppProgressBar(value: 0.25),
+        AppProgressBar(value: 0.55),
+        AppProgressBar(value: 0.85),
+        AppProgressBar(value: 1.0, isOverdue: false),
+        AppProgressBar(value: 1.0, isOverdue: true),
+      ],
+    ),
+  );
 }

--- a/lib/ui/common/components/app_section_header.dart
+++ b/lib/ui/common/components/app_section_header.dart
@@ -1,6 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_typography.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 

--- a/lib/ui/common/components/app_section_header.dart
+++ b/lib/ui/common/components/app_section_header.dart
@@ -56,39 +56,25 @@ class AppSectionHeader extends StatelessWidget {
 @Preview()
 Widget previewProgressBar() => const AppSectionHeaderShowCase();
 
-final class AppSectionHeaderShowCase extends StatelessWidget {
+final class AppSectionHeaderShowCase extends PreviewShowCase {
   const AppSectionHeaderShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final c = context.appColorScheme;
-    return PreviewWrapper(
-      child: Container(
-        color: c.bg,
-        padding: const EdgeInsets.all(24),
-        child: const SizedBox(
-          width: 320,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            spacing: 16,
-            children: [
-              AppSectionHeader(title: Text('タイトルのみ')),
-              AppSectionHeader(
-                title: Text('タイトルのみ長い文章長い文章長い文章長い文章長い文章長い文章長い文章'),
-              ),
-              AppSectionHeader(
-                title: Text('タイトルとサブタイトル'),
-                subTitle: Text('サブタイトル'),
-              ),
-              AppSectionHeader(
-                title: Text('前景色・背景色指定', style: TextStyle(color: Colors.white)),
-                backgroundColor: Colors.red,
-              ),
-            ],
-          ),
+  Widget buildPreview(BuildContext context) => const SizedBox(
+    width: 320,
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      spacing: 16,
+      children: [
+        AppSectionHeader(title: Text('タイトルのみ')),
+        AppSectionHeader(title: Text('タイトルのみ長い文章長い文章長い文章長い文章長い文章長い文章長い文章')),
+        AppSectionHeader(title: Text('タイトルとサブタイトル'), subTitle: Text('サブタイトル')),
+        AppSectionHeader(
+          title: Text('前景色・背景色指定', style: TextStyle(color: Colors.white)),
+          backgroundColor: Colors.red,
         ),
-      ),
-    );
-  }
+      ],
+    ),
+  );
 }

--- a/lib/ui/common/components/app_snack_bar.dart
+++ b/lib/ui/common/components/app_snack_bar.dart
@@ -61,6 +61,10 @@ abstract final class AppSnackBar {
     text: context.l10n.appDetailUpdateHistorySuccess,
     actionLabel: context.l10n.commonUndo,
   ),
+  TaskExecutionDeleteSuccess() => (
+    text: context.l10n.appDetailDeleteHistorySuccess,
+    actionLabel: context.l10n.commonUndo,
+  ),
   DebugDummyTasksGeneratedMessage() => (
     text: context.l10n.settingsDebugDummyTasksGenerated,
     actionLabel: '',

--- a/lib/ui/common/components/app_snack_bar.dart
+++ b/lib/ui/common/components/app_snack_bar.dart
@@ -74,42 +74,38 @@ abstract final class AppSnackBar {
 @Preview()
 Widget previewSnackBar() => const SnackBarShowCase();
 
-final class SnackBarShowCase extends StatelessWidget {
+final class SnackBarShowCase extends PreviewShowCase {
   const SnackBarShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return PreviewWrapper(
-      child: ScaffoldMessenger(
-        child: Scaffold(
-          body: Builder(
-            builder: (context) => Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                spacing: 12,
-                children: [
-                  AppButton(
-                    label: '完了通知',
-                    onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
-                      AppSnackBar.create(message: '「オイル交換」の完了を記録しました'),
-                    ),
-                  ),
-                  AppButton(
-                    label: '登録通知（取り消しあり）',
-                    onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
-                      AppSnackBar.createWithAction(
-                        message: '「歯ブラシ交換」を登録しました',
-                        actionLabel: '取り消し',
-                        onAction: () {},
-                      ),
-                    ),
-                  ),
-                ],
+  Widget buildPreview(BuildContext context) => ScaffoldMessenger(
+    child: Scaffold(
+      body: Builder(
+        builder: (context) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 12,
+            children: [
+              AppButton(
+                label: '完了通知',
+                onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                  AppSnackBar.create(message: '「オイル交換」の完了を記録しました'),
+                ),
               ),
-            ),
+              AppButton(
+                label: '登録通知（取り消しあり）',
+                onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                  AppSnackBar.createWithAction(
+                    message: '「歯ブラシ交換」を登録しました',
+                    actionLabel: '取り消し',
+                    onAction: () {},
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ),
-    );
-  }
+    ),
+  );
 }

--- a/lib/ui/common/components/app_snack_bar.dart
+++ b/lib/ui/common/components/app_snack_bar.dart
@@ -2,7 +2,7 @@ import 'dart:async' show unawaited;
 
 import 'package:dawnbreaker/core/util/context_extension.dart';
 import 'package:dawnbreaker/ui/common/components/app_button.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:dawnbreaker/ui/common/snack_bar_message.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';

--- a/lib/ui/common/components/app_task_icon_tile.dart
+++ b/lib/ui/common/components/app_task_icon_tile.dart
@@ -74,47 +74,38 @@ class AppTaskIconTile extends StatelessWidget {
 @Preview()
 Widget previewTaskIconTile() => const TaskIconTileShowCase();
 
-final class TaskIconTileShowCase extends StatelessWidget {
+final class TaskIconTileShowCase extends PreviewShowCase {
   const TaskIconTileShowCase({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final bg = context.appColorScheme.bg;
-    return PreviewWrapper(
-      child: Container(
-        color: bg,
-        padding: const EdgeInsets.all(24),
-        child: const Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          spacing: 16,
-          children: [
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              spacing: 8,
-              children: [
-                AppTaskIconTile(emoji: '🚗', color: TaskColor.none),
-                AppTaskIconTile(emoji: '🌿', color: TaskColor.red),
-                AppTaskIconTile(emoji: '❄️', color: TaskColor.blue),
-                AppTaskIconTile(emoji: '🐝', color: TaskColor.yellow),
-                AppTaskIconTile(emoji: '🪴', color: TaskColor.green),
-                AppTaskIconTile(emoji: '🧺', color: TaskColor.orange),
-              ],
-            ),
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              spacing: 8,
-              children: [
-                AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 32),
-                AppTaskIconTile(emoji: '🚗', color: TaskColor.none),
-                AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 48),
-                AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 52),
-              ],
-            ),
-          ],
-        ),
+  Widget buildPreview(BuildContext context) => const Column(
+    mainAxisSize: MainAxisSize.min,
+    crossAxisAlignment: CrossAxisAlignment.start,
+    spacing: 16,
+    children: [
+      Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 8,
+        children: [
+          AppTaskIconTile(emoji: '🚗', color: TaskColor.none),
+          AppTaskIconTile(emoji: '🌿', color: TaskColor.red),
+          AppTaskIconTile(emoji: '❄️', color: TaskColor.blue),
+          AppTaskIconTile(emoji: '🐝', color: TaskColor.yellow),
+          AppTaskIconTile(emoji: '🪴', color: TaskColor.green),
+          AppTaskIconTile(emoji: '🧺', color: TaskColor.orange),
+        ],
       ),
-    );
-  }
+      Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        spacing: 8,
+        children: [
+          AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 32),
+          AppTaskIconTile(emoji: '🚗', color: TaskColor.none),
+          AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 48),
+          AppTaskIconTile(emoji: '🚗', color: TaskColor.none, size: 52),
+        ],
+      ),
+    ],
+  );
 }

--- a/lib/ui/common/components/app_task_icon_tile.dart
+++ b/lib/ui/common/components/app_task_icon_tile.dart
@@ -1,6 +1,6 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/data/model/task_color.dart';
-import 'package:dawnbreaker/ui/common/components/preview_wrapper.dart';
+import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
 

--- a/lib/ui/common/components/preview_show_case.dart
+++ b/lib/ui/common/components/preview_show_case.dart
@@ -2,8 +2,17 @@ import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_theme.dart';
 import 'package:flutter/material.dart';
 
-class PreviewWrapper extends StatelessWidget {
-  const PreviewWrapper({super.key, required this.builder});
+abstract class PreviewShowCase extends StatelessWidget {
+  const PreviewShowCase({super.key});
+
+  @override
+  Widget build(BuildContext context) => _PreviewWrapper(builder: buildPreview);
+
+  Widget buildPreview(BuildContext context);
+}
+
+class _PreviewWrapper extends StatelessWidget {
+  const _PreviewWrapper({required this.builder});
 
   final WidgetBuilder builder;
 
@@ -22,13 +31,4 @@ class PreviewWrapper extends StatelessWidget {
       ),
     );
   }
-}
-
-abstract class PreviewShowCase extends StatelessWidget {
-  const PreviewShowCase({super.key});
-
-  @override
-  Widget build(BuildContext context) => PreviewWrapper(builder: buildPreview);
-
-  Widget buildPreview(BuildContext context);
 }

--- a/lib/ui/common/components/preview_wrapper.dart
+++ b/lib/ui/common/components/preview_wrapper.dart
@@ -1,13 +1,34 @@
+import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_theme.dart';
 import 'package:flutter/material.dart';
 
 class PreviewWrapper extends StatelessWidget {
-  const PreviewWrapper({super.key, required this.child});
+  const PreviewWrapper({super.key, required this.builder});
 
-  final Widget child;
+  final WidgetBuilder builder;
 
   @override
   Widget build(BuildContext context) {
-    return Theme(data: createThemeData(context), child: child);
+    return Theme(
+      data: createThemeData(context),
+      child: Builder(
+        builder: (context) => ColoredBox(
+          color: context.appColorScheme.bg,
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: builder(context),
+          ),
+        ),
+      ),
+    );
   }
+}
+
+abstract class PreviewShowCase extends StatelessWidget {
+  const PreviewShowCase({super.key});
+
+  @override
+  Widget build(BuildContext context) => PreviewWrapper(builder: buildPreview);
+
+  Widget buildPreview(BuildContext context);
 }

--- a/lib/ui/common/dialog_message.dart
+++ b/lib/ui/common/dialog_message.dart
@@ -34,6 +34,11 @@ class TaskDeleteErrorMessage extends DialogMessage {
   TaskDeleteErrorMessage({super.handler}) : super(type: DialogType.error);
 }
 
+class TaskExecutionDeleteErrorMessage extends DialogMessage {
+  TaskExecutionDeleteErrorMessage({super.handler})
+    : super(type: DialogType.error);
+}
+
 class TaskInvalidArgumentErrorMessage extends DialogMessage {
   TaskInvalidArgumentErrorMessage() : super(type: DialogType.error);
 }

--- a/lib/ui/common/snack_bar_message.dart
+++ b/lib/ui/common/snack_bar_message.dart
@@ -35,6 +35,10 @@ class TaskExecutionUpdateSuccess extends SnackBarMessage {
   TaskExecutionUpdateSuccess({required super.handler});
 }
 
+class TaskExecutionDeleteSuccess extends SnackBarMessage {
+  TaskExecutionDeleteSuccess({required super.handler});
+}
+
 class DebugDummyTasksGeneratedMessage extends SnackBarMessage {
   DebugDummyTasksGeneratedMessage();
 }

--- a/lib/ui/home/widgets/task_complete_sheet.dart
+++ b/lib/ui/home/widgets/task_complete_sheet.dart
@@ -6,6 +6,7 @@ import 'package:dawnbreaker/core/util/date_util.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/ui/common/components/app_button.dart';
 import 'package:dawnbreaker/ui/common/components/app_input.dart';
+import 'package:dawnbreaker/ui/common/components/app_long_press_button.dart';
 import 'package:dawnbreaker/ui/common/components/app_section_header.dart';
 import 'package:dawnbreaker/ui/common/components/app_task_icon_tile.dart';
 import 'package:flutter/cupertino.dart';
@@ -17,12 +18,14 @@ class TaskCompleteSheet extends StatefulWidget {
     super.key,
     required this.task,
     required this.onConfirm,
+    this.onDelete,
     this.initialDate,
     this.initialComment,
   });
 
   final TaskItem task;
   final void Function(DateTime date, String? comment) onConfirm;
+  final VoidCallback? onDelete;
   final DateTime? initialDate;
   final String? initialComment;
 
@@ -30,15 +33,17 @@ class TaskCompleteSheet extends StatefulWidget {
     BuildContext context, {
     required TaskItem task,
     required void Function(DateTime date, String? comment) onConfirm,
+    VoidCallback? onDelete,
     DateTime? initialDate,
     String? initialComment,
   }) => showModalBottomSheet<void>(
     context: context,
     showDragHandle: true,
     isScrollControlled: true,
-    builder: (_) => TaskCompleteSheet(
+    builder: (ctx) => TaskCompleteSheet(
       task: task,
       onConfirm: onConfirm,
+      onDelete: onDelete,
       initialDate: initialDate,
       initialComment: initialComment,
     ),
@@ -86,7 +91,21 @@ class _TaskCompleteSheetState extends State<TaskCompleteSheet> {
             const SizedBox(height: 16),
             ..._commentArea,
             const SizedBox(height: 24),
-            _buttonArea,
+            _buttonArea(
+              onConfirm: () {
+                Navigator.of(context).pop();
+                final comment = _commentController.text.trim();
+                widget.onConfirm(
+                  _selectedDate,
+                  comment.isEmpty ? null : comment,
+                );
+              },
+              onDelete: () {
+                Navigator.of(context).pop();
+                widget.onDelete?.call();
+              },
+              onCancel: () => Navigator.of(context).pop(),
+            ),
           ],
         ),
       ),
@@ -162,37 +181,62 @@ class _TaskCompleteSheetState extends State<TaskCompleteSheet> {
     ];
   }
 
-  Widget get _buttonArea {
-    return Row(
-      children: [
-        Expanded(
-          flex: 2,
-          child: AppButton(
+  Widget _buttonArea({
+    required VoidCallback onConfirm,
+    required VoidCallback onDelete,
+    required VoidCallback onCancel,
+  }) {
+    if (widget.initialDate == null) {
+      return Row(
+        children: [
+          Expanded(
+            flex: 2,
+            child: AppButton(
+              label: context.l10n.commonCancel,
+              variant: AppButtonVariant.secondary,
+              size: AppButtonSize.large,
+              fullWidth: true,
+              onPressed: onCancel,
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            flex: 3,
+            child: AppButton(
+              label: context.l10n.homeCompleteRecord,
+              size: AppButtonSize.large,
+              fullWidth: true,
+              onPressed: onConfirm,
+              tintColor: widget.task.color,
+            ),
+          ),
+        ],
+      );
+    } else {
+      return Column(
+        spacing: 8,
+        children: [
+          AppButton(
+            label: context.l10n.editorSaveEdit,
+            size: AppButtonSize.large,
+            fullWidth: true,
+            onPressed: onConfirm,
+            tintColor: widget.task.color,
+          ),
+          AppLongPressButton(
+            label: '長押しで削除',
+            size: AppButtonSize.large,
+            onLongPress: onDelete,
+          ),
+          AppButton(
             label: context.l10n.commonCancel,
             variant: AppButtonVariant.secondary,
             size: AppButtonSize.large,
             fullWidth: true,
-            onPressed: () => Navigator.of(context).pop(),
+            onPressed: onCancel,
           ),
-        ),
-        const SizedBox(width: 10),
-        Expanded(
-          flex: 3,
-          child: AppButton(
-            label: widget.initialDate != null
-                ? context.l10n.editorSaveEdit
-                : context.l10n.homeCompleteRecord,
-            size: AppButtonSize.large,
-            fullWidth: true,
-            onPressed: () {
-              Navigator.of(context).pop();
-              final comment = _commentController.text.trim();
-              widget.onConfirm(_selectedDate, comment.isEmpty ? null : comment);
-            },
-            tintColor: widget.task.color,
-          ),
-        ),
-      ],
-    );
+        ],
+      );
+    }
   }
 }

--- a/lib/ui/home/widgets/task_complete_sheet.dart
+++ b/lib/ui/home/widgets/task_complete_sheet.dart
@@ -224,7 +224,7 @@ class _TaskCompleteSheetState extends State<TaskCompleteSheet> {
             tintColor: widget.task.color,
           ),
           AppLongPressButton(
-            label: '長押しで削除',
+            label: context.l10n.appDetailDeleteHistoryButton,
             size: AppButtonSize.large,
             onLongPress: onDelete,
           ),

--- a/test/helpers/fake_task_repository.dart
+++ b/test/helpers/fake_task_repository.dart
@@ -14,7 +14,7 @@ class FakeTaskRepository implements TaskRepository {
     this.shouldThrow = false,
   }) : _tasks = List.of(initialTasks);
 
-  final bool shouldThrow;
+  bool shouldThrow;
   final List<TaskItem> _tasks;
   final _controller = StreamController<List<TaskItem>>.broadcast();
   int _nextId = 100;

--- a/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
+++ b/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
@@ -6,6 +6,7 @@ import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/data/model/task_type.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository_exception.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository_impl.dart';
+import 'package:dawnbreaker/ui/app_detail/viewmodel/app_detail_ui_state.dart';
 import 'package:dawnbreaker/ui/app_detail/viewmodel/app_detail_view_model.dart';
 import 'package:dawnbreaker/ui/common/dialog_message.dart';
 import 'package:dawnbreaker/ui/common/snack_bar_message.dart';
@@ -20,11 +21,41 @@ void main() {
   group('AppDetailViewModel', () {
     late ProviderContainer container;
     late FakeTaskRepository fakeRepository;
+    late AppDetailViewModelProvider provider;
+    late AppDetailViewModel viewModel;
+    late AppDetailUiState viewState;
 
-    void setUpContainer() {
+    void setUpContainer({int? taskId}) {
       fakeRepository = FakeTaskRepository(initialTasks: _testTasks);
       container = ProviderContainer(
         overrides: [taskRepositoryProvider.overrideWith((_) => fakeRepository)],
+      );
+      provider = appDetailViewModelProvider(
+        taskId: taskId ?? _taskOneHistory.id,
+      );
+    }
+
+    Future<void> setUpLoaded({int? taskId}) async {
+      final id = taskId ?? _taskOneHistory.id;
+      setUpContainer(taskId: id);
+      await _waitUntilLoaded(container, taskId: id);
+      viewModel = container.read(provider.notifier);
+      container.listen(
+        provider,
+        (_, next) => viewState = next,
+        fireImmediately: true,
+      );
+    }
+
+    Future<void> setUpLoadedWithThrow() async {
+      setUpContainer();
+      fakeRepository.shouldThrow = true;
+      await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+      viewModel = container.read(provider.notifier);
+      container.listen(
+        provider,
+        (_, next) => viewState = next,
+        fireImmediately: true,
       );
     }
 
@@ -37,9 +68,7 @@ void main() {
       setUp(setUpContainer);
 
       test('データ取得前はローディング中でタスクは表示されない', () {
-        final state = container.read(
-          appDetailViewModelProvider(taskId: _taskOneHistory.id),
-        );
+        final state = container.read(provider);
         expect(state.isLoading, true);
         expect(state.task, isNull);
         expect(state.historyStats, isNull);
@@ -50,131 +79,75 @@ void main() {
     group('ロード後', () {
       group('履歴なしのタスク', () {
         setUp(() async {
-          setUpContainer();
-          await _waitUntilLoaded(container, taskId: _taskNoHistory.id);
+          await setUpLoaded(taskId: _taskNoHistory.id);
         });
 
         test('タスクの内容が表示できる状態になる', () {
-          final state = container.read(
-            appDetailViewModelProvider(taskId: _taskNoHistory.id),
-          );
-          expect(state.isLoading, false);
-          expect(state.task, _taskNoHistory);
+          expect(viewState.isLoading, false);
+          expect(viewState.task, _taskNoHistory);
         });
 
         test('履歴がないため実行記録が含まれない', () {
-          final stats = container
-              .read(appDetailViewModelProvider(taskId: _taskNoHistory.id))
-              .historyStats;
-          expect(stats, isNotNull);
-          expect(stats!.historyAndInterval, isEmpty);
+          expect(viewState.historyStats, isNotNull);
+          expect(viewState.historyStats!.historyAndInterval, isEmpty);
         });
 
         test('一度も実行されていないため経過日数は算出されない', () {
-          expect(
-            container
-                .read(appDetailViewModelProvider(taskId: _taskNoHistory.id))
-                .daysSinceLastExecution,
-            isNull,
-          );
+          expect(viewState.daysSinceLastExecution, isNull);
         });
 
         test('インターバル計算には2件以上の履歴が必要なため平均インターバルは算出されない', () {
-          expect(
-            container
-                .read(appDetailViewModelProvider(taskId: _taskNoHistory.id))
-                .averageIntervalDays,
-            isNull,
-          );
+          expect(viewState.averageIntervalDays, isNull);
         });
       });
 
       group('履歴1件のタスク', () {
         setUp(() async {
-          setUpContainer();
-          await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+          await setUpLoaded();
         });
 
         test('タスクの内容が表示できる状態になる', () {
-          expect(
-            container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .task,
-            _taskOneHistory,
-          );
+          expect(viewState.task, _taskOneHistory);
         });
 
         test('最終実行日からの経過日数が計算される', () {
-          expect(
-            container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .daysSinceLastExecution,
-            isNotNull,
-          );
+          expect(viewState.daysSinceLastExecution, isNotNull);
         });
 
         test('インターバル計算には2件以上の履歴が必要なため平均インターバルは算出されない', () {
-          expect(
-            container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .averageIntervalDays,
-            isNull,
-          );
+          expect(viewState.averageIntervalDays, isNull);
         });
 
         test('すべての履歴エントリが一覧に含まれる', () {
-          final stats = container
-              .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-              .historyStats;
-          expect(stats!.historyAndInterval, hasLength(1));
+          expect(viewState.historyStats!.historyAndInterval, hasLength(1));
         });
       });
 
       group('複数履歴のタスク', () {
         setUp(() async {
-          setUpContainer();
-          await _waitUntilLoaded(container, taskId: _taskMultiHistory.id);
+          await setUpLoaded(taskId: _taskMultiHistory.id);
         });
 
         test('タスクの内容が表示できる状態になる', () {
-          expect(
-            container
-                .read(appDetailViewModelProvider(taskId: _taskMultiHistory.id))
-                .task,
-            _taskMultiHistory,
-          );
+          expect(viewState.task, _taskMultiHistory);
         });
 
         test('すべての履歴エントリが一覧に含まれる', () {
-          final stats = container
-              .read(appDetailViewModelProvider(taskId: _taskMultiHistory.id))
-              .historyStats;
-          expect(stats!.historyAndInterval, hasLength(3));
+          expect(viewState.historyStats!.historyAndInterval, hasLength(3));
         });
 
         test('実行インターバルの平均が正しく計算される', () {
-          expect(
-            container
-                .read(appDetailViewModelProvider(taskId: _taskMultiHistory.id))
-                .averageIntervalDays,
-            31,
-          );
+          expect(viewState.averageIntervalDays, 31);
         });
 
         test('最終実行日からの経過日数が計算される', () {
-          expect(
-            container
-                .read(appDetailViewModelProvider(taskId: _taskMultiHistory.id))
-                .daysSinceLastExecution,
-            isNotNull,
-          );
+          expect(viewState.daysSinceLastExecution, isNotNull);
         });
       });
 
       group('タスクが外部で更新されたとき', () {
         setUp(() async {
-          setUpContainer();
-          await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+          await setUpLoaded();
         });
 
         test('編集内容がリアルタイムで画面に反映される', () async {
@@ -185,12 +158,9 @@ void main() {
             icon: '✂️',
             color: TaskColor.green,
           );
-          final state = container.read(
-            appDetailViewModelProvider(taskId: _taskOneHistory.id),
-          );
-          expect(state.task?.name, '更新後の名前');
-          expect(state.task?.icon, '✂️');
-          expect(state.task?.color, TaskColor.green);
+          expect(viewState.task?.name, '更新後の名前');
+          expect(viewState.task?.icon, '✂️');
+          expect(viewState.task?.color, TaskColor.green);
         });
 
         test('タスク更新後も履歴情報が正しく表示される', () async {
@@ -201,189 +171,95 @@ void main() {
             icon: '📝',
             color: TaskColor.none,
           );
-          final stats = container
-              .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-              .historyStats;
-          expect(stats, isNotNull);
-          expect(stats!.historyAndInterval, hasLength(1));
+          expect(viewState.historyStats, isNotNull);
+          expect(viewState.historyStats!.historyAndInterval, hasLength(1));
         });
       });
 
       group('タスクデータの取得中にエラーが発生したとき', () {
         setUp(() async {
-          setUpContainer();
-          await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+          await setUpLoaded();
         });
 
         test('画面を閉じる状態になる', () async {
           fakeRepository.emitError(const TaskLoadException('stream error'));
           await Future.microtask(() {});
-          expect(
-            container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .shouldPop,
-            true,
-          );
+          expect(viewState.shouldPop, true);
         });
 
         test('ローディング状態が解除される', () async {
           fakeRepository.emitError(const TaskLoadException('stream error'));
           await Future.microtask(() {});
-          expect(
-            container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .isLoading,
-            false,
-          );
+          expect(viewState.isLoading, false);
         });
       });
 
       group('updateExecution', () {
         group('正常系', () {
           setUp(() async {
-            setUpContainer();
-            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+            await setUpLoaded();
           });
 
           test('成功時はエラーなし', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .updateExecution(
-                  _taskOneHistory.taskHistory.first,
-                  executedAt: DateTime(2026, 2, 1),
-                );
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage,
-              isNull,
+            await viewModel.updateExecution(
+              _taskOneHistory.taskHistory.first,
+              executedAt: DateTime(2026, 2, 1),
             );
+            expect(viewState.dialogMessage, isNull);
           });
 
           test('コメントありで更新してもエラーなし', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .updateExecution(
-                  _taskOneHistory.taskHistory.first,
-                  executedAt: DateTime(2026, 2, 1),
-                  comment: '更新コメント',
-                );
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage,
-              isNull,
+            await viewModel.updateExecution(
+              _taskOneHistory.taskHistory.first,
+              executedAt: DateTime(2026, 2, 1),
+              comment: '更新コメント',
             );
+            expect(viewState.dialogMessage, isNull);
           });
 
           test('成功時に更新完了の通知がセットされる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .updateExecution(
-                  _taskOneHistory.taskHistory.first,
-                  executedAt: DateTime(2026, 2, 1),
-                );
+            await viewModel.updateExecution(
+              _taskOneHistory.taskHistory.first,
+              executedAt: DateTime(2026, 2, 1),
+            );
             expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .snackBarMessage,
+              viewState.snackBarMessage,
               isA<TaskExecutionUpdateSuccess>(),
             );
           });
 
           test('undo ハンドラを呼び出すと元の日時・コメントで再更新される', () async {
-            final original = _taskOneHistory.taskHistory.first;
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .updateExecution(
-                  original,
-                  executedAt: DateTime(2026, 2, 1),
-                  comment: '変更後',
-                );
-
-            final handler = container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .snackBarMessage
-                ?.handler;
+            await viewModel.updateExecution(
+              _taskOneHistory.taskHistory.first,
+              executedAt: DateTime(2026, 2, 1),
+              comment: '変更後',
+            );
+            final handler = viewState.snackBarMessage?.handler;
             expect(handler, isNotNull);
             await handler!();
-
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage,
-              isNull,
-            );
+            expect(viewState.dialogMessage, isNull);
           });
         });
 
         group('異常系', () {
           setUp(() async {
-            fakeRepository = FakeTaskRepository(
-              initialTasks: _testTasks,
-              shouldThrow: true,
-            );
-            container = ProviderContainer(
-              overrides: [
-                taskRepositoryProvider.overrideWith((_) => fakeRepository),
-              ],
-            );
-            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+            await setUpLoadedWithThrow();
           });
 
           test('失敗時に更新エラーの通知がセットされる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .updateExecution(
-                  _taskOneHistory.taskHistory.first,
-                  executedAt: DateTime(2026, 2, 1),
-                );
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage,
-              isA<TaskUpdateErrorMessage>(),
+            await viewModel.updateExecution(
+              _taskOneHistory.taskHistory.first,
+              executedAt: DateTime(2026, 2, 1),
             );
+            expect(viewState.dialogMessage, isA<TaskUpdateErrorMessage>());
           });
 
           test('失敗時に再試行できる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .updateExecution(
-                  _taskOneHistory.taskHistory.first,
-                  executedAt: DateTime(2026, 2, 1),
-                );
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage
-                  ?.handler,
-              isNotNull,
+            await viewModel.updateExecution(
+              _taskOneHistory.taskHistory.first,
+              executedAt: DateTime(2026, 2, 1),
             );
+            expect(viewState.dialogMessage?.handler, isNotNull);
           });
         });
       });
@@ -391,80 +267,48 @@ void main() {
       group('recordExecution', () {
         group('正常系', () {
           setUp(() async {
-            setUpContainer();
-            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+            await setUpLoaded();
           });
 
           test('成功時はエラーなし', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
-
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage,
-              isNull,
+            await viewModel.recordExecution(
+              _taskOneHistory,
+              DateTime(2026, 4, 1),
+              null,
             );
+            expect(viewState.dialogMessage, isNull);
           });
 
           test('成功時に実行完了の通知がセットされる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
-
-            final msg = container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .snackBarMessage;
+            await viewModel.recordExecution(
+              _taskOneHistory,
+              DateTime(2026, 4, 1),
+              null,
+            );
+            final msg = viewState.snackBarMessage;
             expect(msg, isA<TaskCompleteSuccess>());
             expect((msg as TaskCompleteSuccess).taskName, _taskOneHistory.name);
           });
 
           test('成功時の通知に undo ハンドラがある', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
-
-            final msg = container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .snackBarMessage;
-            expect(msg?.handler, isNotNull);
+            await viewModel.recordExecution(
+              _taskOneHistory,
+              DateTime(2026, 4, 1),
+              null,
+            );
+            expect(viewState.snackBarMessage?.handler, isNotNull);
           });
 
           test('undo ハンドラを呼び出してもエラーが発生しない', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
-
-            final handler = container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .snackBarMessage
-                ?.handler;
+            await viewModel.recordExecution(
+              _taskOneHistory,
+              DateTime(2026, 4, 1),
+              null,
+            );
+            final handler = viewState.snackBarMessage?.handler;
             expect(handler, isNotNull);
             await handler!();
-
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage,
-              isNull,
-            );
+            expect(viewState.dialogMessage, isNull);
           });
 
           for (final (comment, expectedComment, description) in [
@@ -472,128 +316,61 @@ void main() {
             ('良い感じ', '良い感じ', 'コメントあり'),
           ]) {
             test('$descriptionで記録するとリポジトリにコメントが渡される', () async {
-              await container
-                  .read(
-                    appDetailViewModelProvider(
-                      taskId: _taskOneHistory.id,
-                    ).notifier,
-                  )
-                  .recordExecution(
-                    _taskOneHistory,
-                    DateTime(2026, 4, 1),
-                    comment,
-                  );
-
-              expect(fakeRepository.lastRecordedComment, expectedComment);
-              expect(
-                container
-                    .read(
-                      appDetailViewModelProvider(taskId: _taskOneHistory.id),
-                    )
-                    .snackBarMessage,
-                isA<TaskCompleteSuccess>(),
+              await viewModel.recordExecution(
+                _taskOneHistory,
+                DateTime(2026, 4, 1),
+                comment,
               );
+              expect(fakeRepository.lastRecordedComment, expectedComment);
+              expect(viewState.snackBarMessage, isA<TaskCompleteSuccess>());
             });
           }
         });
 
         group('異常系', () {
           setUp(() async {
-            fakeRepository = FakeTaskRepository(
-              initialTasks: _testTasks,
-              shouldThrow: true,
-            );
-            container = ProviderContainer(
-              overrides: [
-                taskRepositoryProvider.overrideWith((_) => fakeRepository),
-              ],
-            );
-            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+            await setUpLoadedWithThrow();
           });
 
           test('リポジトリがエラーを返すと dialogMessage がセットされる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
-
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage,
-              isA<TaskSaveErrorMessage>(),
+            await viewModel.recordExecution(
+              _taskOneHistory,
+              DateTime(2026, 4, 1),
+              null,
             );
+            expect(viewState.dialogMessage, isA<TaskSaveErrorMessage>());
           });
 
           test('失敗時に再試行できる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .recordExecution(_taskOneHistory, DateTime(2026, 4, 1), null);
-
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage
-                  ?.handler,
-              isNotNull,
+            await viewModel.recordExecution(
+              _taskOneHistory,
+              DateTime(2026, 4, 1),
+              null,
             );
+            expect(viewState.dialogMessage?.handler, isNotNull);
           });
         });
       });
 
       group('showDeleteTaskDialog', () {
         setUp(() async {
-          setUpContainer();
-          await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+          await setUpLoaded();
         });
 
         test('確認ダイアログが表示される', () {
-          container
-              .read(
-                appDetailViewModelProvider(taskId: _taskOneHistory.id).notifier,
-              )
-              .showDeleteTaskDialog();
-          expect(
-            container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .dialogMessage,
-            isA<DeleteTaskConfirmMessage>(),
-          );
+          viewModel.showDeleteTaskDialog();
+          expect(viewState.dialogMessage, isA<DeleteTaskConfirmMessage>());
         });
 
         test('ダイアログにタスク名が表示される', () {
-          container
-              .read(
-                appDetailViewModelProvider(taskId: _taskOneHistory.id).notifier,
-              )
-              .showDeleteTaskDialog();
-          final msg =
-              container
-                      .read(
-                        appDetailViewModelProvider(taskId: _taskOneHistory.id),
-                      )
-                      .dialogMessage
-                  as DeleteTaskConfirmMessage?;
+          viewModel.showDeleteTaskDialog();
+          final msg = viewState.dialogMessage as DeleteTaskConfirmMessage?;
           expect(msg?.taskName, _taskOneHistory.name);
         });
 
         test('ダイアログのハンドラを呼び出すとタスクが削除される', () async {
-          container
-              .read(
-                appDetailViewModelProvider(taskId: _taskOneHistory.id).notifier,
-              )
-              .showDeleteTaskDialog();
-          final handler = container
-              .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-              .dialogMessage
-              ?.handler;
+          viewModel.showDeleteTaskDialog();
+          final handler = viewState.dialogMessage?.handler;
           expect(handler, isNotNull);
           handler!();
           await Future.microtask(() {});
@@ -604,141 +381,54 @@ void main() {
       group('deleteTask', () {
         group('正常系', () {
           setUp(() async {
-            setUpContainer();
-            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+            await setUpLoaded();
           });
 
           test('前の画面に戻る', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteTask();
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .shouldPop,
-              true,
-            );
+            await viewModel.deleteTask();
+            expect(viewState.shouldPop, true);
           });
 
           test('削除成功の通知がタスク名付きで表示される', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteTask();
-            final msg = container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .snackBarMessage;
+            await viewModel.deleteTask();
+            final msg = viewState.snackBarMessage;
             expect(msg, isA<TaskDeleteSuccess>());
             expect((msg as TaskDeleteSuccess).taskName, _taskOneHistory.name);
           });
 
           test('削除を取り消せる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteTask();
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .snackBarMessage
-                  ?.handler,
-              isNotNull,
-            );
+            await viewModel.deleteTask();
+            expect(viewState.snackBarMessage?.handler, isNotNull);
           });
 
           // 削除によりストリームが null を流すため clearTaskItem が呼ばれる
           test('タスクデータがクリアされる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteTask();
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .task,
-              isNull,
-            );
+            await viewModel.deleteTask();
+            expect(viewState.task, isNull);
           });
 
           test('undo ハンドラを呼び出すとタスクが復元される', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteTask();
-
+            await viewModel.deleteTask();
             expect(fakeRepository.containsTask(_taskOneHistory.id), false);
-
-            final handler = container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .snackBarMessage
-                ?.handler;
+            final handler = viewState.snackBarMessage?.handler;
             await handler!();
-
             expect(fakeRepository.containsTask(_taskOneHistory.id), true);
           });
         });
 
         group('異常系', () {
           setUp(() async {
-            fakeRepository = FakeTaskRepository(
-              initialTasks: _testTasks,
-              shouldThrow: true,
-            );
-            container = ProviderContainer(
-              overrides: [
-                taskRepositoryProvider.overrideWith((_) => fakeRepository),
-              ],
-            );
-            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+            await setUpLoadedWithThrow();
           });
 
           test('削除失敗のエラーが通知される', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteTask();
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage,
-              isA<TaskDeleteErrorMessage>(),
-            );
+            await viewModel.deleteTask();
+            expect(viewState.dialogMessage, isA<TaskDeleteErrorMessage>());
           });
 
           test('削除を再試行できる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteTask();
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage
-                  ?.handler,
-              isNotNull,
-            );
+            await viewModel.deleteTask();
+            expect(viewState.dialogMessage?.handler, isNotNull);
           });
         });
       });
@@ -746,91 +436,45 @@ void main() {
       group('deleteExecution', () {
         group('正常系', () {
           setUp(() async {
-            setUpContainer();
-            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+            await setUpLoaded();
           });
 
           test('成功時はエラーなし', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteExecution(
-                  _taskOneHistory,
-                  _taskOneHistory.taskHistory.first,
-                );
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage,
-              isNull,
+            await viewModel.deleteExecution(
+              _taskOneHistory,
+              _taskOneHistory.taskHistory.first,
             );
+            expect(viewState.dialogMessage, isNull);
           });
 
           test('成功時に削除完了の通知がセットされる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteExecution(
-                  _taskOneHistory,
-                  _taskOneHistory.taskHistory.first,
-                );
+            await viewModel.deleteExecution(
+              _taskOneHistory,
+              _taskOneHistory.taskHistory.first,
+            );
             expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .snackBarMessage,
+              viewState.snackBarMessage,
               isA<TaskExecutionDeleteSuccess>(),
             );
           });
 
           test('成功時の通知に undo ハンドラがある', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteExecution(
-                  _taskOneHistory,
-                  _taskOneHistory.taskHistory.first,
-                );
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .snackBarMessage
-                  ?.handler,
-              isNotNull,
+            await viewModel.deleteExecution(
+              _taskOneHistory,
+              _taskOneHistory.taskHistory.first,
             );
+            expect(viewState.snackBarMessage?.handler, isNotNull);
           });
 
           test('undo ハンドラを呼び出してもエラーが発生しない', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteExecution(
-                  _taskOneHistory,
-                  _taskOneHistory.taskHistory.first,
-                );
-            final handler = container
-                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                .snackBarMessage
-                ?.handler;
+            await viewModel.deleteExecution(
+              _taskOneHistory,
+              _taskOneHistory.taskHistory.first,
+            );
+            final handler = viewState.snackBarMessage?.handler;
             expect(handler, isNotNull);
             await handler!();
-            expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage,
-              isNull,
-            );
+            expect(viewState.dialogMessage, isNull);
           });
 
           for (final (comment, expectedComment, description) in [
@@ -843,17 +487,8 @@ void main() {
                 executedAt: DateTime(2026, 1, 1),
                 comment: comment,
               );
-              await container
-                  .read(
-                    appDetailViewModelProvider(
-                      taskId: _taskOneHistory.id,
-                    ).notifier,
-                  )
-                  .deleteExecution(_taskOneHistory, history);
-              final handler = container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .snackBarMessage
-                  ?.handler;
+              await viewModel.deleteExecution(_taskOneHistory, history);
+              final handler = viewState.snackBarMessage?.handler;
               await handler!();
               expect(fakeRepository.lastRecordedComment, expectedComment);
             });
@@ -862,54 +497,43 @@ void main() {
 
         group('異常系', () {
           setUp(() async {
-            fakeRepository = FakeTaskRepository(
-              initialTasks: _testTasks,
-              shouldThrow: true,
-            );
-            container = ProviderContainer(
-              overrides: [
-                taskRepositoryProvider.overrideWith((_) => fakeRepository),
-              ],
-            );
-            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+            await setUpLoadedWithThrow();
           });
 
           test('失敗時に削除エラーの通知がセットされる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteExecution(
-                  _taskOneHistory,
-                  _taskOneHistory.taskHistory.first,
-                );
+            await viewModel.deleteExecution(
+              _taskOneHistory,
+              _taskOneHistory.taskHistory.first,
+            );
             expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage,
+              viewState.dialogMessage,
               isA<TaskExecutionDeleteErrorMessage>(),
             );
           });
 
           test('失敗時に再試行できる', () async {
-            await container
-                .read(
-                  appDetailViewModelProvider(
-                    taskId: _taskOneHistory.id,
-                  ).notifier,
-                )
-                .deleteExecution(
-                  _taskOneHistory,
-                  _taskOneHistory.taskHistory.first,
-                );
+            await viewModel.deleteExecution(
+              _taskOneHistory,
+              _taskOneHistory.taskHistory.first,
+            );
+            expect(viewState.dialogMessage?.handler, isNotNull);
+          });
+
+          test('リトライハンドラを呼び出すと再度削除が試みられ成功する', () async {
+            await viewModel.deleteExecution(
+              _taskOneHistory,
+              _taskOneHistory.taskHistory.first,
+            );
+            final handler = viewState.dialogMessage?.handler;
+            expect(handler, isNotNull);
+
+            fakeRepository.shouldThrow = false;
+            handler!();
+            await Future.microtask(() {});
+
             expect(
-              container
-                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
-                  .dialogMessage
-                  ?.handler,
-              isNotNull,
+              viewState.snackBarMessage,
+              isA<TaskExecutionDeleteSuccess>(),
             );
           });
         });

--- a/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
+++ b/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
@@ -742,6 +742,178 @@ void main() {
           });
         });
       });
+
+      group('deleteExecution', () {
+        group('正常系', () {
+          setUp(() async {
+            setUpContainer();
+            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+          });
+
+          test('成功時はエラーなし', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .deleteExecution(
+                  _taskOneHistory,
+                  _taskOneHistory.taskHistory.first,
+                );
+            expect(
+              container
+                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                  .dialogMessage,
+              isNull,
+            );
+          });
+
+          test('成功時に削除完了の通知がセットされる', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .deleteExecution(
+                  _taskOneHistory,
+                  _taskOneHistory.taskHistory.first,
+                );
+            expect(
+              container
+                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                  .snackBarMessage,
+              isA<TaskExecutionDeleteSuccess>(),
+            );
+          });
+
+          test('成功時の通知に undo ハンドラがある', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .deleteExecution(
+                  _taskOneHistory,
+                  _taskOneHistory.taskHistory.first,
+                );
+            expect(
+              container
+                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                  .snackBarMessage
+                  ?.handler,
+              isNotNull,
+            );
+          });
+
+          test('undo ハンドラを呼び出してもエラーが発生しない', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .deleteExecution(
+                  _taskOneHistory,
+                  _taskOneHistory.taskHistory.first,
+                );
+            final handler = container
+                .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                .snackBarMessage
+                ?.handler;
+            expect(handler, isNotNull);
+            await handler!();
+            expect(
+              container
+                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                  .dialogMessage,
+              isNull,
+            );
+          });
+
+          for (final (comment, expectedComment, description) in [
+            (null, null, 'コメントなし'),
+            ('メモあり', 'メモあり', 'コメントあり'),
+          ]) {
+            test('$descriptionの履歴を削除後 undo で元のコメントが再作成される', () async {
+              final history = TaskHistory(
+                id: 1,
+                executedAt: DateTime(2026, 1, 1),
+                comment: comment,
+              );
+              await container
+                  .read(
+                    appDetailViewModelProvider(
+                      taskId: _taskOneHistory.id,
+                    ).notifier,
+                  )
+                  .deleteExecution(_taskOneHistory, history);
+              final handler = container
+                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                  .snackBarMessage
+                  ?.handler;
+              await handler!();
+              expect(fakeRepository.lastRecordedComment, expectedComment);
+            });
+          }
+        });
+
+        group('異常系', () {
+          setUp(() async {
+            fakeRepository = FakeTaskRepository(
+              initialTasks: _testTasks,
+              shouldThrow: true,
+            );
+            container = ProviderContainer(
+              overrides: [
+                taskRepositoryProvider.overrideWith((_) => fakeRepository),
+              ],
+            );
+            await _waitUntilLoaded(container, taskId: _taskOneHistory.id);
+          });
+
+          test('失敗時に削除エラーの通知がセットされる', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .deleteExecution(
+                  _taskOneHistory,
+                  _taskOneHistory.taskHistory.first,
+                );
+            expect(
+              container
+                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                  .dialogMessage,
+              isA<TaskExecutionDeleteErrorMessage>(),
+            );
+          });
+
+          test('失敗時に再試行できる', () async {
+            await container
+                .read(
+                  appDetailViewModelProvider(
+                    taskId: _taskOneHistory.id,
+                  ).notifier,
+                )
+                .deleteExecution(
+                  _taskOneHistory,
+                  _taskOneHistory.taskHistory.first,
+                );
+            expect(
+              container
+                  .read(appDetailViewModelProvider(taskId: _taskOneHistory.id))
+                  .dialogMessage
+                  ?.handler,
+              isNotNull,
+            );
+          });
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

- `AppLongPressButton` を新規追加（長押し中にプログレスフィルが進み、完了で `onLongPress` を発火）
- タスク完了モーダルに「長押しで削除」ボタンを追加（履歴の更新モードのみ表示）
- `AppButtonSize` を `app_button_size.dart` に切り出し、`AppLongPressButton` でも再利用
- `PreviewShowCase` 抽象クラスを導入してプレビューのテーマ伝搬バグを修正、全コンポーネントのショーケースを統一
- 履歴削除の成功・失敗メッセージ（`TaskExecutionDeleteSuccess` / `TaskExecutionDeleteErrorMessage`）を追加し、undo でリポジトリから再作成できるようにした
- `deleteExecution` の ViewModel テストを追加（正常系・異常系・undo ハンドラ検証）

## Test plan

- [x] `fvm flutter test test/ui/app_detail/viewmodel/app_detail_view_model_test.dart` が全パスすること
- [x] タスク完了モーダル（新規登録）でキャンセル・登録が正常に動作すること
- [x] タスク完了モーダル（履歴編集）で長押しボタンが表示され、長押し完了で削除・モーダルが閉じること
- [x] 削除後に「完了記録を削除しました」スナックバーが表示され、「取り消し」で元に戻せること
- [x] 長押し途中で指を離すとアニメーションがフェードアウトすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)