### PR TITLE
Refactor test setup to reduce boilerplate and improve readability

### DIFF
--- a/test/ui/editor/viewmodel/editor_view_model_test.dart
+++ b/test/ui/editor/viewmodel/editor_view_model_test.dart
@@ -5,6 +5,7 @@ import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/data/model/task_type.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository_impl.dart';
 import 'package:dawnbreaker/ui/common/snack_bar_message.dart';
+import 'package:dawnbreaker/ui/editor/viewmodel/editor_ui_state.dart';
 import 'package:dawnbreaker/ui/editor/viewmodel/editor_view_model.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,6 +19,25 @@ void main() {
   group('EditorViewModel', () {
     late ProviderContainer container;
     late FakeTaskRepository fakeRepository;
+    late EditorViewModel viewModel;
+    late EditorUiState viewState;
+
+    void setUpContainer() {
+      fakeRepository = FakeTaskRepository(initialTasks: _testTasks);
+      container = ProviderContainer(
+        overrides: [
+          taskRepositoryProvider.overrideWith((_) => fakeRepository),
+        ],
+      );
+    }
+
+    Future<void> setUpLoaded({int? taskId}) async {
+      setUpContainer();
+      final p = editorViewModelProvider(taskId: taskId);
+      await waitUntil(container, p, (s) => !s.isLoading);
+      viewModel = container.read(p.notifier);
+      container.listen(p, (_, next) => viewState = next, fireImmediately: true);
+    }
 
     tearDown(() {
       container.dispose();
@@ -25,86 +45,68 @@ void main() {
     });
 
     group('新規作成モード', () {
-      late ProviderSubscription<EditorViewModel> sub;
-      late EditorViewModel viewModel;
-
       setUp(() {
-        fakeRepository = FakeTaskRepository(initialTasks: _testTasks);
-        container = ProviderContainer(
-          overrides: [
-            taskRepositoryProvider.overrideWith((_) => fakeRepository),
-          ],
-        );
-        sub = container.listen(editorViewModelProvider().notifier, (_, _) {});
-        viewModel = container.read(editorViewModelProvider().notifier);
+        setUpContainer();
+        final p = editorViewModelProvider();
+        viewModel = container.read(p.notifier);
+        container.listen(p, (_, next) => viewState = next, fireImmediately: true);
       });
 
-      tearDown(() => sub.close());
-
       test('初期状態が正しい', () {
-        final state = container.read(editorViewModelProvider());
-        expect(state.isLoading, false);
-        expect(state.icon, '📝');
-        expect(state.name, '');
-        expect(state.type, TaskType.period);
-        expect(state.color, TaskColor.none);
-        expect(state.isSaved, false);
-        expect(state.dialogMessage, isNull);
+        expect(viewState.isLoading, false);
+        expect(viewState.icon, '📝');
+        expect(viewState.name, '');
+        expect(viewState.type, TaskType.period);
+        expect(viewState.color, TaskColor.none);
+        expect(viewState.isSaved, false);
+        expect(viewState.dialogMessage, isNull);
       });
 
       test('name が空のとき canSave は false', () {
-        expect(container.read(editorViewModelProvider()).canSave, false);
+        expect(viewState.canSave, false);
       });
 
-      test('updateName で name が更新され canSave が true になる', () {
+      test('名前を入力すると canSave が true になる', () {
         viewModel.updateName('散髪');
-        final state = container.read(editorViewModelProvider());
-        expect(state.name, '散髪');
-        expect(state.canSave, true);
+        expect(viewState.name, '散髪');
+        expect(viewState.canSave, true);
       });
 
-      test('updateIcon で icon が更新される', () {
+      test('アイコンを変更できる', () {
         viewModel.updateIcon('✂️');
-        expect(container.read(editorViewModelProvider()).icon, '✂️');
+        expect(viewState.icon, '✂️');
       });
 
-      test('updateType で type が更新される', () {
+      test('タスク種別を変更できる', () {
         viewModel.updateType(TaskType.scheduled);
-        expect(
-          container.read(editorViewModelProvider()).type,
-          TaskType.scheduled,
-        );
+        expect(viewState.type, TaskType.scheduled);
       });
 
-      test('updateColor で color が更新される', () {
+      test('カラーを変更できる', () {
         viewModel.updateColor(TaskColor.blue);
-        expect(container.read(editorViewModelProvider()).color, TaskColor.blue);
+        expect(viewState.color, TaskColor.blue);
       });
 
-      test('updateScheduleValue で scheduleValue が更新される', () {
+      test('スケジュール間隔を変更できる', () {
         viewModel.updateScheduleValue(3);
-        expect(container.read(editorViewModelProvider()).scheduleValue, 3);
+        expect(viewState.scheduleValue, 3);
       });
 
-      test('updateScheduleUnit で scheduleUnit が更新される', () {
+      test('スケジュール単位を変更できる', () {
         viewModel.updateScheduleUnit(ScheduleUnit.week);
-        expect(
-          container.read(editorViewModelProvider()).scheduleUnit,
-          ScheduleUnit.week,
-        );
+        expect(viewState.scheduleUnit, ScheduleUnit.week);
       });
 
       test('name が空のとき save() は何もしない', () async {
         await viewModel.save();
-        final state = container.read(editorViewModelProvider());
-        expect(state.isSaved, false);
-        expect(state.isLoading, false);
+        expect(viewState.isSaved, false);
+        expect(viewState.isLoading, false);
       });
 
       test('period タスクを save() すると isSaved: true になる', () async {
         viewModel.updateName('散髪');
         await viewModel.save();
-        expect(container.read(editorViewModelProvider()).isSaved, true);
+        expect(viewState.isSaved, true);
       });
 
       test('scheduled タスクを save() すると isSaved: true になる', () async {
@@ -112,33 +114,26 @@ void main() {
           ..updateName('虫避け交換')
           ..updateType(TaskType.scheduled);
         await viewModel.save();
-        expect(container.read(editorViewModelProvider()).isSaved, true);
+        expect(viewState.isSaved, true);
       });
 
-      test(
-        'save() 成功後に snackBarMessage が TaskCreateSuccessSnackMessage になる',
-        () async {
-          viewModel.updateName('散髪');
-          await viewModel.save();
-          final state = container.read(editorViewModelProvider());
-          expect(state.snackBarMessage, isA<TaskCreateSuccess>());
-          expect((state.snackBarMessage as TaskCreateSuccess).taskName, '散髪');
-          expect(state.snackBarMessage!.handler, isNotNull);
-        },
-      );
+      test('save() 成功後に作成完了の通知がセットされる', () async {
+        viewModel.updateName('散髪');
+        await viewModel.save();
+        expect(viewState.snackBarMessage, isA<TaskCreateSuccess>());
+        expect((viewState.snackBarMessage as TaskCreateSuccess).taskName, '散髪');
+        expect(viewState.snackBarMessage!.handler, isNotNull);
+      });
 
       test('create の undo ハンドラを実行するとタスクがリポジトリから削除される', () async {
         viewModel.updateName('散髪');
         await viewModel.save();
-        final snackMsg = container
-            .read(editorViewModelProvider())
-            .snackBarMessage;
-        expect(snackMsg, isA<TaskCreateSuccess>());
+        expect(viewState.snackBarMessage, isA<TaskCreateSuccess>());
 
         // undo 前はタスクが存在する
         expect(fakeRepository.containsTask(100), true);
 
-        await snackMsg!.handler!();
+        await viewState.snackBarMessage!.handler!();
 
         expect(fakeRepository.containsTask(100), false);
       });
@@ -148,33 +143,26 @@ void main() {
         final c = ProviderContainer(
           overrides: [taskRepositoryProvider.overrideWith((_) => throwingRepo)],
         );
-        final s = c.listen(editorViewModelProvider().notifier, (_, _) {});
+        final p = editorViewModelProvider();
+        EditorUiState? localState;
+        c.listen(p, (_, next) => localState = next, fireImmediately: true);
         addTearDown(() {
-          s.close();
           c.dispose();
           throwingRepo.dispose();
         });
-        final n = c.read(editorViewModelProvider().notifier);
+        final n = c.read(p.notifier);
         n.updateName('散髪');
         await n.save();
-        final state = c.read(editorViewModelProvider());
-        expect(state.isSaved, false);
-        expect(state.isSaving, false);
-        expect(state.dialogMessage, isNotNull);
+        expect(localState!.isSaved, false);
+        expect(localState!.isSaving, false);
+        expect(localState!.dialogMessage, isNotNull);
       });
     });
 
     group('編集モード', () {
-      setUp(() {
-        fakeRepository = FakeTaskRepository(initialTasks: _testTasks);
-        container = ProviderContainer(
-          overrides: [
-            taskRepositoryProvider.overrideWith((_) => fakeRepository),
-          ],
-        );
-      });
-
       group('初期状態', () {
+        setUp(setUpContainer);
+
         test('データ取得中である', () {
           final state = container.read(editorViewModelProvider(taskId: 1));
           expect(state.isLoading, true);
@@ -182,108 +170,72 @@ void main() {
       });
 
       group('ロード後', () {
-        test('period タスクの内容が反映される', () async {
-          await waitUntil(
-            container,
-            editorViewModelProvider(taskId: 1),
-            (s) => !s.isLoading,
-          );
-          final state = container.read(editorViewModelProvider(taskId: 1));
-          expect(state.isLoading, false);
-          expect(state.name, '歯ブラシ交換');
-          expect(state.icon, '🪥');
-          expect(state.type, TaskType.period);
-          expect(state.color, TaskColor.blue);
-          expect(state.taskHistory, hasLength(1));
+        group('period タスク', () {
+          setUp(() async => setUpLoaded(taskId: 1));
+
+          test('タスクの内容が反映される', () {
+            expect(viewState.isLoading, false);
+            expect(viewState.name, '歯ブラシ交換');
+            expect(viewState.icon, '🪥');
+            expect(viewState.type, TaskType.period);
+            expect(viewState.color, TaskColor.blue);
+            expect(viewState.taskHistory, hasLength(1));
+          });
         });
 
-        test('scheduled タスクのスケジュール設定が反映される', () async {
-          await waitUntil(
-            container,
-            editorViewModelProvider(taskId: 2),
-            (s) => !s.isLoading,
-          );
-          final state = container.read(editorViewModelProvider(taskId: 2));
-          expect(state.isLoading, false);
-          expect(state.type, TaskType.scheduled);
-          expect(state.scheduleValue, 2);
-          expect(state.scheduleUnit, ScheduleUnit.week);
+        group('scheduled タスク', () {
+          setUp(() async => setUpLoaded(taskId: 2));
+
+          test('スケジュール設定が反映される', () {
+            expect(viewState.isLoading, false);
+            expect(viewState.type, TaskType.scheduled);
+            expect(viewState.scheduleValue, 2);
+            expect(viewState.scheduleUnit, ScheduleUnit.week);
+          });
         });
 
-        test('存在しないタスクのとき errorMessage が設定される', () async {
-          await waitUntil(
-            container,
-            editorViewModelProvider(taskId: 999),
-            (s) => !s.isLoading,
-          );
-          final state = container.read(editorViewModelProvider(taskId: 999));
-          expect(state.isLoading, false);
-          expect(state.dialogMessage, isNotNull);
+        group('タスクが存在しない場合', () {
+          setUp(() async => setUpLoaded(taskId: 999));
+
+          test('読み込みエラーが通知される', () {
+            expect(viewState.isLoading, false);
+            expect(viewState.dialogMessage, isNotNull);
+          });
         });
 
         group('save', () {
+          setUp(() async => setUpLoaded(taskId: 1));
+
           group('正常系', () {
             test('編集内容を保存できる', () async {
-              await waitUntil(
-                container,
-                editorViewModelProvider(taskId: 1),
-                (s) => !s.isLoading,
-              );
-              final notifier = container.read(
-                editorViewModelProvider(taskId: 1).notifier,
-              );
-              notifier.updateColor(TaskColor.green);
-              await notifier.save();
-              expect(
-                container.read(editorViewModelProvider(taskId: 1)).isSaved,
-                true,
-              );
+              viewModel.updateColor(TaskColor.green);
+              await viewModel.save();
+              expect(viewState.isSaved, true);
             });
 
             test('保存成功後に更新完了の通知がセットされる', () async {
-              await waitUntil(
-                container,
-                editorViewModelProvider(taskId: 1),
-                (s) => !s.isLoading,
-              );
-              final notifier = container.read(
-                editorViewModelProvider(taskId: 1).notifier,
-              );
-              notifier.updateName('新しい名前');
-              await notifier.save();
-              final state = container.read(editorViewModelProvider(taskId: 1));
-              expect(state.snackBarMessage, isA<TaskUpdateSuccess>());
+              viewModel.updateName('新しい名前');
+              await viewModel.save();
+              expect(viewState.snackBarMessage, isA<TaskUpdateSuccess>());
               expect(
-                (state.snackBarMessage as TaskUpdateSuccess).taskName,
+                (viewState.snackBarMessage as TaskUpdateSuccess).taskName,
                 '新しい名前',
               );
-              expect(state.snackBarMessage!.handler, isNotNull);
+              expect(viewState.snackBarMessage!.handler, isNotNull);
             });
 
             test('undo ハンドラを実行すると元のタスクの状態に戻る', () async {
-              await waitUntil(
-                container,
-                editorViewModelProvider(taskId: 1),
-                (s) => !s.isLoading,
-              );
-              final notifier = container.read(
-                editorViewModelProvider(taskId: 1).notifier,
-              );
+              viewModel.updateName('新しい名前');
+              viewModel.updateColor(TaskColor.green);
+              await viewModel.save();
 
-              notifier.updateName('新しい名前');
-              notifier.updateColor(TaskColor.green);
-              await notifier.save();
-
-              final snackMsg = container
-                  .read(editorViewModelProvider(taskId: 1))
-                  .snackBarMessage;
-              expect(snackMsg, isA<TaskUpdateSuccess>());
+              expect(viewState.snackBarMessage, isA<TaskUpdateSuccess>());
 
               // undo 前は更新後の値
               expect(fakeRepository.taskById(1)?.name, '新しい名前');
               expect(fakeRepository.taskById(1)?.color, TaskColor.green);
 
-              await snackMsg!.handler!();
+              await viewState.snackBarMessage!.handler!();
 
               // undo 後は元の値に戻っている
               expect(fakeRepository.taskById(1)?.name, '歯ブラシ交換');

--- a/test/ui/home/viewmodel/home_view_model_test.dart
+++ b/test/ui/home/viewmodel/home_view_model_test.dart
@@ -102,13 +102,26 @@ void main() {
   group('HomeViewModel', () {
     late ProviderContainer container;
     late FakeTaskRepository fakeRepository;
+    late HomeViewModel viewModel;
+    late HomeUiState viewState;
 
-    setUp(() {
-      fakeRepository = FakeTaskRepository(initialTasks: _testTasks);
+    void setUpContainer({List<TaskItem>? tasks}) {
+      fakeRepository = FakeTaskRepository(initialTasks: tasks ?? _testTasks);
       container = ProviderContainer(
         overrides: [taskRepositoryProvider.overrideWith((_) => fakeRepository)],
       );
-    });
+    }
+
+    Future<void> setUpLoaded({List<TaskItem>? tasks}) async {
+      setUpContainer(tasks: tasks);
+      await waitUntil(container, homeViewModelProvider, (s) => !s.isLoading);
+      viewModel = container.read(homeViewModelProvider.notifier);
+      container.listen(
+        homeViewModelProvider,
+        (_, next) => viewState = next,
+        fireImmediately: true,
+      );
+    }
 
     tearDown(() {
       container.dispose();
@@ -116,6 +129,8 @@ void main() {
     });
 
     group('初期状態', () {
+      setUp(setUpContainer);
+
       test('ローディング中でタスクが表示されない', () {
         final state = container.read(homeViewModelProvider);
         expect(state.isLoading, true);
@@ -129,94 +144,77 @@ void main() {
     });
 
     group('ロード後', () {
-      setUp(() async {
-        await waitUntil(container, homeViewModelProvider, (s) => !s.isLoading);
-      });
+      setUp(() async => setUpLoaded());
 
       test('タスクが読み込まれる', () {
-        final state = container.read(homeViewModelProvider);
-        expect(state.isLoading, false);
-        expect(state.tasks, _testTasks);
+        expect(viewState.isLoading, false);
+        expect(viewState.tasks, _testTasks);
       });
 
       test('hasTasks は true', () {
-        expect(container.read(homeViewModelProvider).hasTasks, true);
+        expect(viewState.hasTasks, true);
       });
 
       test('searchQuery が空のとき全タスクを返す', () {
-        final tl = container.read(homeViewModelProvider).taskList;
+        final tl = viewState.taskList;
         expect([...tl.overdueTasks, ...tl.upcomingTasks], _testTasks);
       });
 
-      test('updateSearchQuery で絞り込まれる', () {
-        container.read(homeViewModelProvider.notifier).updateSearchQuery('歯');
-        final tl = container.read(homeViewModelProvider).taskList;
-        final all = [...tl.overdueTasks, ...tl.upcomingTasks];
-        expect(all.isNotEmpty, true);
-        expect(all.every((t) => t.name.contains('歯')), true);
-      });
+      group('updateSearchQuery', () {
+        test('一致するタスクに絞り込まれる', () {
+          viewModel.updateSearchQuery('歯');
+          final tl = viewState.taskList;
+          final all = [...tl.overdueTasks, ...tl.upcomingTasks];
+          expect(all.isNotEmpty, true);
+          expect(all.every((t) => t.name.contains('歯')), true);
+        });
 
-      test('一致しない searchQuery のとき taskList は空', () {
-        container.read(homeViewModelProvider.notifier).updateSearchQuery('zzz');
-        final tl = container.read(homeViewModelProvider).taskList;
-        expect(tl.overdueTasks, isEmpty);
-        expect(tl.upcomingTasks, isEmpty);
-        expect(tl.isEmpty, true);
-      });
+        test('一致しない場合は taskList が空になる', () {
+          viewModel.updateSearchQuery('zzz');
+          final tl = viewState.taskList;
+          expect(tl.overdueTasks, isEmpty);
+          expect(tl.upcomingTasks, isEmpty);
+          expect(tl.isEmpty, true);
+        });
 
-      test('updateSearchQuery で searchQuery が更新される', () {
-        container.read(homeViewModelProvider.notifier).updateSearchQuery('歯');
-        expect(container.read(homeViewModelProvider).searchQuery, '歯');
-      });
+        test('検索クエリが更新される', () {
+          viewModel.updateSearchQuery('歯');
+          expect(viewState.searchQuery, '歯');
+        });
 
-      test('updateSearchQuery に同じ値を渡してもステートが変わらない', () {
-        container.read(homeViewModelProvider.notifier).updateSearchQuery('歯');
-        final stateBefore = container.read(homeViewModelProvider);
+        test('同じ値を渡してもステートが変わらない', () {
+          viewModel.updateSearchQuery('歯');
+          final stateBefore = viewState;
 
-        container.read(homeViewModelProvider.notifier).updateSearchQuery('歯');
-        final stateAfter = container.read(homeViewModelProvider);
+          viewModel.updateSearchQuery('歯');
+          final stateAfter = viewState;
 
-        expect(identical(stateBefore, stateAfter), true);
+          expect(identical(stateBefore, stateAfter), true);
+        });
       });
 
       group('updateFilter', () {
-        test('selectedFilter が変わる', () {
-          container
-              .read(homeViewModelProvider.notifier)
-              .updateFilter(HomeFilter.overdue);
-          expect(
-            container.read(homeViewModelProvider).selectedFilter,
-            HomeFilter.overdue,
-          );
+        test('フィルターが切り替わる', () {
+          viewModel.updateFilter(HomeFilter.overdue);
+          expect(viewState.selectedFilter, HomeFilter.overdue);
         });
 
         test('同じフィルタを渡してもステートが変わらない', () {
-          final before = container.read(homeViewModelProvider);
-          container
-              .read(homeViewModelProvider.notifier)
-              .updateFilter(HomeFilter.all);
-          expect(
-            identical(container.read(homeViewModelProvider), before),
-            true,
-          );
+          final before = viewState;
+          viewModel.updateFilter(HomeFilter.all);
+          expect(identical(viewState, before), true);
         });
 
         test('overdue フィルタ: 期日のないタスクは除外される', () {
-          // _testTasks は PeriodTask 履歴1件 → 期日未定なので overdue では空
-          container
-              .read(homeViewModelProvider.notifier)
-              .updateFilter(HomeFilter.overdue);
-          final tl = container.read(homeViewModelProvider).taskList;
+          viewModel.updateFilter(HomeFilter.overdue);
+          final tl = viewState.taskList;
           expect(tl.overdueTasks, isEmpty);
           expect(tl.upcomingTasks, isEmpty);
         });
 
         test('irregular フィルタ: 期日のないタスクが upcoming に返る', () {
-          // _testTasks はいずれも期日未定
-          container
-              .read(homeViewModelProvider.notifier)
-              .updateFilter(HomeFilter.irregular);
-          final tl = container.read(homeViewModelProvider).taskList;
+          viewModel.updateFilter(HomeFilter.irregular);
+          final tl = viewState.taskList;
           expect(tl.upcomingTasks, _testTasks);
         });
       });
@@ -224,46 +222,44 @@ void main() {
       group('recordExecution', () {
         group('正常系', () {
           test('成功時はエラーなし', () async {
-            await container
-                .read(homeViewModelProvider.notifier)
-                .recordExecution(_testTasks[0], DateTime(2026, 4, 1), null);
-
-            expect(container.read(homeViewModelProvider).dialogMessage, isNull);
+            await viewModel.recordExecution(
+              _testTasks[0],
+              DateTime(2026, 4, 1),
+              null,
+            );
+            expect(viewState.dialogMessage, isNull);
           });
 
           test('成功時に実行完了の通知がセットされる', () async {
-            await container
-                .read(homeViewModelProvider.notifier)
-                .recordExecution(_testTasks[0], DateTime(2026, 4, 1), null);
-
-            final msg = container.read(homeViewModelProvider).snackBarMessage;
+            await viewModel.recordExecution(
+              _testTasks[0],
+              DateTime(2026, 4, 1),
+              null,
+            );
+            final msg = viewState.snackBarMessage;
             expect(msg, isA<TaskCompleteSuccess>());
             expect((msg as TaskCompleteSuccess).taskName, _testTasks[0].name);
           });
 
           test('成功時の通知に undo ハンドラがある', () async {
-            await container
-                .read(homeViewModelProvider.notifier)
-                .recordExecution(_testTasks[0], DateTime(2026, 4, 1), null);
-
-            final msg = container.read(homeViewModelProvider).snackBarMessage;
-            expect(msg?.handler, isNotNull);
+            await viewModel.recordExecution(
+              _testTasks[0],
+              DateTime(2026, 4, 1),
+              null,
+            );
+            expect(viewState.snackBarMessage?.handler, isNotNull);
           });
 
           test('undo ハンドラを呼び出してもエラーが発生しない', () async {
-            await container
-                .read(homeViewModelProvider.notifier)
-                .recordExecution(_testTasks[0], DateTime(2026, 4, 1), null);
-
-            final handler = container
-                .read(homeViewModelProvider)
-                .snackBarMessage
-                ?.handler;
+            await viewModel.recordExecution(
+              _testTasks[0],
+              DateTime(2026, 4, 1),
+              null,
+            );
+            final handler = viewState.snackBarMessage?.handler;
             expect(handler, isNotNull);
-
             await handler!();
-
-            expect(container.read(homeViewModelProvider).dialogMessage, isNull);
+            expect(viewState.dialogMessage, isNull);
           });
 
           for (final (comment, expectedComment, description) in [
@@ -271,19 +267,13 @@ void main() {
             ('良い感じ', '良い感じ', 'コメントあり'),
           ]) {
             test('$descriptionで記録するとリポジトリにコメントが渡される', () async {
-              await container
-                  .read(homeViewModelProvider.notifier)
-                  .recordExecution(
-                    _testTasks[0],
-                    DateTime(2026, 4, 1),
-                    comment,
-                  );
-
-              expect(fakeRepository.lastRecordedComment, expectedComment);
-              expect(
-                container.read(homeViewModelProvider).snackBarMessage,
-                isA<TaskCompleteSuccess>(),
+              await viewModel.recordExecution(
+                _testTasks[0],
+                DateTime(2026, 4, 1),
+                comment,
               );
+              expect(fakeRepository.lastRecordedComment, expectedComment);
+              expect(viewState.snackBarMessage, isA<TaskCompleteSuccess>());
             });
           }
         });
@@ -310,131 +300,77 @@ void main() {
           });
         });
       });
+    });
 
-      group('taskList 分類', () {
-        late ProviderContainer classContainer;
-        late FakeTaskRepository classRepo;
+    group('taskList 分類', () {
+      setUp(() async => setUpLoaded(tasks: classificationTasks));
 
-        setUp(() async {
-          classRepo = FakeTaskRepository(initialTasks: classificationTasks);
-          classContainer = ProviderContainer(
-            overrides: [taskRepositoryProvider.overrideWith((_) => classRepo)],
-          );
-          await waitUntil(
-            classContainer,
-            homeViewModelProvider,
-            (s) => !s.isLoading,
-          );
-        });
-
-        tearDown(() {
-          classContainer.dispose();
-          classRepo.dispose();
-        });
-
-        test('all フィルタ: 超過タスクが overdue、それ以外が upcoming に入る', () {
-          final tl = classContainer.read(homeViewModelProvider).taskList;
-          expect(tl.overdueTasks.length, 1);
-          expect(tl.overdueTasks.first.name, '超過');
-          expect(tl.upcomingTasks.length, 4);
-        });
-
-        test('overdue フィルタ: 超過タスクのみ残る', () {
-          classContainer
-              .read(homeViewModelProvider.notifier)
-              .updateFilter(HomeFilter.overdue);
-          final tl = classContainer.read(homeViewModelProvider).taskList;
-          expect(tl.overdueTasks.map((t) => t.name), ['超過']);
-          expect(tl.upcomingTasks, isEmpty);
-        });
-
-        test('today フィルタ: 今日期限タスクのみ upcoming に入る', () {
-          classContainer
-              .read(homeViewModelProvider.notifier)
-              .updateFilter(HomeFilter.today);
-          final tl = classContainer.read(homeViewModelProvider).taskList;
-          expect(tl.overdueTasks, isEmpty);
-          expect(tl.upcomingTasks.map((t) => t.name), ['今日']);
-        });
-
-        test('week フィルタ: 今日を含む今週内タスクが upcoming に入る', () {
-          classContainer
-              .read(homeViewModelProvider.notifier)
-              .updateFilter(HomeFilter.week);
-          final tl = classContainer.read(homeViewModelProvider).taskList;
-          expect(tl.overdueTasks, isEmpty);
-          expect(tl.upcomingTasks.map((t) => t.name), ['今日', '今週']);
-        });
-
-        test('irregular フィルタ: 期日のないタスクのみ upcoming に入る', () {
-          classContainer
-              .read(homeViewModelProvider.notifier)
-              .updateFilter(HomeFilter.irregular);
-          final tl = classContainer.read(homeViewModelProvider).taskList;
-          expect(tl.overdueTasks, isEmpty);
-          expect(tl.upcomingTasks.map((t) => t.name), ['不定期']);
-        });
-
-        test('タスクがあるとき isEmpty は false', () {
-          final tl = classContainer.read(homeViewModelProvider).taskList;
-          expect(tl.isEmpty, isFalse);
-        });
-
-        test('一致しない検索クエリのとき isEmpty は true', () {
-          classContainer
-              .read(homeViewModelProvider.notifier)
-              .updateSearchQuery('zzz');
-          final tl = classContainer.read(homeViewModelProvider).taskList;
-          expect(tl.isEmpty, isTrue);
-        });
+      test('all フィルタ: 超過タスクが overdue、それ以外が upcoming に入る', () {
+        final tl = viewState.taskList;
+        expect(tl.overdueTasks.length, 1);
+        expect(tl.overdueTasks.first.name, '超過');
+        expect(tl.upcomingTasks.length, 4);
       });
 
-      group('taskCount', () {
-        late ProviderContainer countContainer;
-        late FakeTaskRepository countRepo;
+      test('overdue フィルタ: 超過タスクのみ残る', () {
+        viewModel.updateFilter(HomeFilter.overdue);
+        final tl = viewState.taskList;
+        expect(tl.overdueTasks.map((t) => t.name), ['超過']);
+        expect(tl.upcomingTasks, isEmpty);
+      });
 
-        setUp(() async {
-          countRepo = FakeTaskRepository(initialTasks: classificationTasks);
-          countContainer = ProviderContainer(
-            overrides: [taskRepositoryProvider.overrideWith((_) => countRepo)],
-          );
-          await waitUntil(
-            countContainer,
-            homeViewModelProvider,
-            (s) => !s.isLoading,
-          );
-        });
+      test('today フィルタ: 今日期限タスクのみ upcoming に入る', () {
+        viewModel.updateFilter(HomeFilter.today);
+        final tl = viewState.taskList;
+        expect(tl.overdueTasks, isEmpty);
+        expect(tl.upcomingTasks.map((t) => t.name), ['今日']);
+      });
 
-        tearDown(() {
-          countContainer.dispose();
-          countRepo.dispose();
-        });
+      test('week フィルタ: 今日を含む今週内タスクが upcoming に入る', () {
+        viewModel.updateFilter(HomeFilter.week);
+        final tl = viewState.taskList;
+        expect(tl.overdueTasks, isEmpty);
+        expect(tl.upcomingTasks.map((t) => t.name), ['今日', '今週']);
+      });
 
-        test('all は全タスク数を返す', () {
-          expect(countContainer.read(homeViewModelProvider).taskCount.all, 5);
-        });
+      test('irregular フィルタ: 期日のないタスクのみ upcoming に入る', () {
+        viewModel.updateFilter(HomeFilter.irregular);
+        final tl = viewState.taskList;
+        expect(tl.overdueTasks, isEmpty);
+        expect(tl.upcomingTasks.map((t) => t.name), ['不定期']);
+      });
 
-        test('overdue は超過タスクのみカウントする', () {
-          expect(
-            countContainer.read(homeViewModelProvider).taskCount.overdue,
-            1,
-          );
-        });
+      test('タスクがあるとき isEmpty は false', () {
+        expect(viewState.taskList.isEmpty, isFalse);
+      });
 
-        test('today は今日期限タスクのみカウントする', () {
-          expect(countContainer.read(homeViewModelProvider).taskCount.today, 1);
-        });
+      test('一致しない検索クエリのとき isEmpty は true', () {
+        viewModel.updateSearchQuery('zzz');
+        expect(viewState.taskList.isEmpty, isTrue);
+      });
+    });
 
-        test('week は today を含む今週内タスクをカウントする', () {
-          expect(countContainer.read(homeViewModelProvider).taskCount.week, 2);
-        });
+    group('taskCount', () {
+      setUp(() async => setUpLoaded(tasks: classificationTasks));
 
-        test('irregular は期日のないタスクのみカウントする', () {
-          expect(
-            countContainer.read(homeViewModelProvider).taskCount.irregular,
-            1,
-          );
-        });
+      test('all は全タスク数を返す', () {
+        expect(viewState.taskCount.all, 5);
+      });
+
+      test('overdue は超過タスクのみカウントする', () {
+        expect(viewState.taskCount.overdue, 1);
+      });
+
+      test('today は今日期限タスクのみカウントする', () {
+        expect(viewState.taskCount.today, 1);
+      });
+
+      test('week は today を含む今週内タスクをカウントする', () {
+        expect(viewState.taskCount.week, 2);
+      });
+
+      test('irregular は期日のないタスクのみカウントする', () {
+        expect(viewState.taskCount.irregular, 1);
       });
     });
   });

--- a/test/ui/onboarding/viewmodel/onboarding_view_model_test.dart
+++ b/test/ui/onboarding/viewmodel/onboarding_view_model_test.dart
@@ -14,6 +14,17 @@ void main() {
   group('OnboardingViewModel', () {
     late ProviderContainer container;
     late FakeOnboardingRepository fakeRepository;
+    late OnboardingViewModel viewModel;
+    late OnboardingUiState viewState;
+
+    void setUpState({OnboardingMode mode = .initial}) {
+      viewModel = container.read(onboardingViewModelProvider(mode: mode).notifier);
+      container.listen(
+        onboardingViewModelProvider(mode: mode),
+        (_, next) => viewState = next,
+        fireImmediately: true,
+      );
+    }
 
     setUp(() {
       fakeRepository = FakeOnboardingRepository();
@@ -27,25 +38,18 @@ void main() {
     tearDown(() => container.dispose());
 
     group('初期状態', () {
+      setUp(setUpState);
+
       test('ボタンが操作可能な状態である', () {
-        final state = container.read(
-          onboardingViewModelProvider(mode: .initial),
-        );
-        expect(state.isLoading, false);
+        expect(viewState.isLoading, false);
       });
 
       test('遷移先が決まっていない', () {
-        final state = container.read(
-          onboardingViewModelProvider(mode: .initial),
-        );
-        expect(state.destination, isNull);
+        expect(viewState.destination, isNull);
       });
 
       test('エラーがない', () {
-        final state = container.read(
-          onboardingViewModelProvider(mode: .initial),
-        );
-        expect(state.dialogMessage, isNull);
+        expect(viewState.dialogMessage, isNull);
       });
     });
 
@@ -64,105 +68,73 @@ void main() {
           ),
         ]) {
           test(description, () async {
-            await container
-                .read(onboardingViewModelProvider(mode: mode).notifier)
-                .onClickDone();
-            final state = container.read(
-              onboardingViewModelProvider(mode: mode),
-            );
-            expect(state.destination, expected);
+            setUpState(mode: mode);
+            await viewModel.onClickDone();
+            expect(viewState.destination, expected);
           });
         }
 
         test('遷移完了まで操作できない状態のままである', () async {
-          await container
-              .read(onboardingViewModelProvider(mode: .initial).notifier)
-              .onClickDone();
-          final state = container.read(
-            onboardingViewModelProvider(mode: .initial),
-          );
-          expect(state.isLoading, true);
+          setUpState();
+          await viewModel.onClickDone();
+          expect(viewState.isLoading, true);
         });
       });
 
       group('異常系', () {
-        setUp(() => fakeRepository.shouldThrow = true);
+        setUp(() {
+          fakeRepository.shouldThrow = true;
+          setUpState();
+        });
 
         test('エラーが通知される', () async {
-          await container
-              .read(onboardingViewModelProvider(mode: .initial).notifier)
-              .onClickDone();
-          final state = container.read(
-            onboardingViewModelProvider(mode: .initial),
-          );
-          expect(state.dialogMessage, isA<OnboardingSaveErrorMessage>());
+          await viewModel.onClickDone();
+          expect(viewState.dialogMessage, isA<OnboardingSaveErrorMessage>());
         });
 
         test('ボタンが操作可能な状態に戻る', () async {
-          await container
-              .read(onboardingViewModelProvider(mode: .initial).notifier)
-              .onClickDone();
-          final state = container.read(
-            onboardingViewModelProvider(mode: .initial),
-          );
-          expect(state.isLoading, false);
+          await viewModel.onClickDone();
+          expect(viewState.isLoading, false);
         });
 
         test('画面遷移しない', () async {
-          await container
-              .read(onboardingViewModelProvider(mode: .initial).notifier)
-              .onClickDone();
-          final state = container.read(
-            onboardingViewModelProvider(mode: .initial),
-          );
-          expect(state.destination, isNull);
+          await viewModel.onClickDone();
+          expect(viewState.destination, isNull);
         });
       });
     });
 
     group('onClickSkip', () {
       group('正常系', () {
+        setUp(setUpState);
+
         test('ホーム画面に遷移する', () async {
-          await container
-              .read(onboardingViewModelProvider(mode: .initial).notifier)
-              .onClickSkip();
-          final state = container.read(
-            onboardingViewModelProvider(mode: .initial),
-          );
-          expect(state.destination, OnboardingDestination.home);
+          await viewModel.onClickSkip();
+          expect(viewState.destination, OnboardingDestination.home);
         });
       });
 
       group('異常系', () {
         test('設定画面からスキップすることはできない', () {
+          setUpState(mode: .fromSettings);
           expect(
-            () => container
-                .read(onboardingViewModelProvider(mode: .fromSettings).notifier)
-                .onClickSkip(),
+            () => viewModel.onClickSkip(),
             throwsStateError,
           );
         });
 
         test('エラーが通知される', () async {
           fakeRepository.shouldThrow = true;
-          await container
-              .read(onboardingViewModelProvider(mode: .initial).notifier)
-              .onClickSkip();
-          final state = container.read(
-            onboardingViewModelProvider(mode: .initial),
-          );
-          expect(state.dialogMessage, isA<OnboardingSaveErrorMessage>());
+          setUpState();
+          await viewModel.onClickSkip();
+          expect(viewState.dialogMessage, isA<OnboardingSaveErrorMessage>());
         });
 
         test('ボタンが操作可能な状態に戻る', () async {
           fakeRepository.shouldThrow = true;
-          await container
-              .read(onboardingViewModelProvider(mode: .initial).notifier)
-              .onClickSkip();
-          final state = container.read(
-            onboardingViewModelProvider(mode: .initial),
-          );
-          expect(state.isLoading, false);
+          setUpState();
+          await viewModel.onClickSkip();
+          expect(viewState.isLoading, false);
         });
       });
     });

--- a/test/ui/settings/viewmodel/settings_view_model_test.dart
+++ b/test/ui/settings/viewmodel/settings_view_model_test.dart
@@ -1,3 +1,4 @@
+import 'package:dawnbreaker/ui/settings/viewmodel/settings_ui_state.dart';
 import 'package:dawnbreaker/ui/settings/viewmodel/settings_view_model.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,6 +9,7 @@ void main() {
 
   group('SettingsViewModel', () {
     late ProviderContainer container;
+    late SettingsUiState viewState;
 
     setUp(() {
       PackageInfo.setMockInitialValues(
@@ -36,16 +38,20 @@ void main() {
 
     group('ロード後', () {
       setUp(() async {
-        container.read(settingsViewModelProvider);
+        container.listen(
+          settingsViewModelProvider,
+          (_, next) => viewState = next,
+          fireImmediately: true,
+        );
         await Future<void>.microtask(() {});
       });
 
       test('バージョンが表示される', () {
-        expect(container.read(settingsViewModelProvider).version, '1.2.3');
+        expect(viewState.version, '1.2.3');
       });
 
       test('読み込みが完了している', () {
-        expect(container.read(settingsViewModelProvider).isLoading, false);
+        expect(viewState.isLoading, false);
       });
     });
   });


### PR DESCRIPTION
## Summary
Refactored test files to extract common setup logic into reusable helper methods and use instance variables for state management, reducing boilerplate and improving test readability.

## Key Changes

- **Extracted setup helpers**: Created `setUpContainer()` and `setUpLoaded()` methods to consolidate repetitive provider container and state initialization logic
- **Introduced instance variables**: Added `viewModel` and `viewState` instance variables to eliminate repeated `container.read()` calls throughout tests
- **Simplified state access**: Tests now access UI state through `viewState` variable instead of calling `container.read()` multiple times per test
- **Improved test organization**: Grouped related tests using nested `group()` blocks (e.g., `updateSearchQuery`, `updateFilter`, `recordExecution`)
- **Parameterized setup**: Made setup methods accept optional parameters (e.g., `tasks`, `taskId`) to support different test scenarios
- **Enhanced test descriptions**: Updated test names to be more concise and descriptive (e.g., "名前を入力すると canSave が true になる" instead of "updateName で name が更新され canSave が true になる")

## Files Modified

- `test/ui/home/viewmodel/home_view_model_test.dart`: Refactored setup logic and state access patterns
- `test/ui/editor/viewmodel/editor_view_model_test.dart`: Applied same refactoring patterns
- `test/ui/onboarding/viewmodel/onboarding_view_model_test.dart`: Simplified state management
- `test/ui/settings/viewmodel/settings_view_model_test.dart`: Updated state access pattern

## Benefits

- Reduced code duplication across test files
- Improved test maintainability by centralizing setup logic
- Enhanced readability with clearer state access patterns
- Easier to add new tests with consistent setup patterns
- Better test organization with nested groups

https://claude.ai/code/session_01W1NT8abrtMkYE3zgJ7QhmD