### PR TITLE
新規タスクの登録でタスク実行履歴は登録しないように修正

### DIFF
--- a/lib/data/repository/task/task_repository.dart
+++ b/lib/data/repository/task/task_repository.dart
@@ -16,7 +16,6 @@ abstract interface class TaskRepository {
     required String name,
     required String icon,
     required TaskColor color,
-    required DateTime executedAt,
     int? scheduleValue,
     ScheduleUnit? scheduleUnit,
   });

--- a/lib/data/repository/task/task_repository_impl.dart
+++ b/lib/data/repository/task/task_repository_impl.dart
@@ -157,7 +157,6 @@ class TaskRepositoryImpl implements TaskRepository {
     required String name,
     required String icon,
     required TaskColor color,
-    required DateTime executedAt,
     int? scheduleValue,
     ScheduleUnit? scheduleUnit,
   }) async {
@@ -192,14 +191,6 @@ class TaskRepositoryImpl implements TaskRepository {
                 ),
               );
         }
-        await _db
-            .into(_db.taskExecutions)
-            .insert(
-              TaskExecutionsCompanion.insert(
-                taskDefinitionId: id,
-                executedAt: executedAt,
-              ),
-            );
         return id;
       });
     } catch (e) {

--- a/lib/ui/app_detail/viewmodel/app_detail_ui_state.dart
+++ b/lib/ui/app_detail/viewmodel/app_detail_ui_state.dart
@@ -34,14 +34,6 @@ abstract class AppDetailUiState with _$AppDetailUiState implements BaseUiState {
     );
   }
 
-  AppDetailUiState clearTaskItem() => copyWith(
-    isLoading: false,
-    task: null,
-    historyStats: null,
-    daysSinceLastExecution: null,
-    averageIntervalDays: null,
-  );
-
   int? _calculateDaysSinceLastExecution(TaskItem task) {
     final last = task.lastExecutedAt?.truncateTime;
     if (last == null) return null;

--- a/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
+++ b/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
@@ -27,9 +27,16 @@ class AppDetailViewModel extends _$AppDetailViewModel {
         .watchTaskById(taskId)
         .listen(
           (task) {
-            // 削除されたときは無視する
+            // 削除されたときは前の画面に戻る
             if (!ref.mounted || task == null) {
-              state = state.clearTaskItem();
+              state = state.copyWith(
+                isLoading: false,
+                task: null,
+                historyStats: null,
+                daysSinceLastExecution: null,
+                averageIntervalDays: null,
+                shouldPop: true,
+              );
             } else {
               state = state.updateTaskItem(task);
             }
@@ -97,12 +104,12 @@ class AppDetailViewModel extends _$AppDetailViewModel {
     try {
       await _repository.deleteTask(task.id);
       if (!ref.mounted) return;
+      // タスク削除で watchTaskById で前の画面に戻る処理が走る
       state = state.copyWith(
         snackBarMessage: TaskDeleteSuccess(
           taskName: task.name,
           handler: () => _repository.restoreTask(task),
         ),
-        shouldPop: true,
       );
     } on TaskRepositoryException {
       if (!ref.mounted) return;

--- a/lib/ui/editor/viewmodel/editor_view_model.dart
+++ b/lib/ui/editor/viewmodel/editor_view_model.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:dawnbreaker/core/util/date_util.dart';
 import 'package:dawnbreaker/data/model/schedule_unit.dart';
 import 'package:dawnbreaker/data/model/task_color.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
@@ -94,7 +93,6 @@ class EditorViewModel extends _$EditorViewModel {
       color: state.color,
       scheduleValue: state.scheduleValue,
       scheduleUnit: state.scheduleUnit,
-      executedAt: DateTime.now().truncateTime,
     );
     return state.copyWith(
       isSaving: false,

--- a/test/data/repository/task/task_repository_test.dart
+++ b/test/data/repository/task/task_repository_test.dart
@@ -67,7 +67,6 @@ void main() {
             name: 'x',
             icon: '📝',
             color: TaskColor.none,
-            executedAt: DateTime.now(),
           ),
           throwsA(isA<TaskSaveException>()),
         );
@@ -155,24 +154,31 @@ void main() {
   group('allTaskItems ソート順', () {
     test('次回予定日が早いタスクが先に来る', () async {
       // 後の scheduledAt を先に追加して、ソートで前に来ることを確認
-      await repository.addTask(
+      final idB = await repository.addTask(
         taskType: TaskType.scheduled,
         name: 'タスクB',
         icon: '📝',
         color: TaskColor.none,
         scheduleValue: 7,
         scheduleUnit: ScheduleUnit.day,
-        executedAt: DateTime(2025, 1, 15), // scheduledAt = 1/22
       );
-      await repository.addTask(
+      await repository.recordExecution(
+        idB,
+        executedAt: DateTime(2025, 1, 15),
+      ); // scheduledAt = 1/22
+
+      final idA = await repository.addTask(
         taskType: TaskType.scheduled,
         name: 'タスクA',
         icon: '📝',
         color: TaskColor.none,
         scheduleValue: 7,
         scheduleUnit: ScheduleUnit.day,
-        executedAt: DateTime(2025, 1, 1), // scheduledAt = 1/8
       );
+      await repository.recordExecution(
+        idA,
+        executedAt: DateTime(2025, 1, 1),
+      ); // scheduledAt = 1/8
 
       final tasks = await repository.allTaskItems().first;
       expect(tasks[0].name, 'タスクA'); // scheduledAt=1/8 が先
@@ -180,23 +186,23 @@ void main() {
     });
 
     test('次回予定日がないタスクは末尾に来る', () async {
-      // PeriodTask 履歴1件 → scheduledAt=null
+      // PeriodTask 履歴0件 → scheduledAt=null
       await repository.addTask(
         taskType: TaskType.period,
         name: '不定期タスク',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
-      await repository.addTask(
+
+      final idS = await repository.addTask(
         taskType: TaskType.scheduled,
         name: '定期タスク',
         icon: '📝',
         color: TaskColor.none,
         scheduleValue: 7,
         scheduleUnit: ScheduleUnit.day,
-        executedAt: DateTime(2025, 1, 1),
       );
+      await repository.recordExecution(idS, executedAt: DateTime(2025, 1, 1));
 
       final tasks = await repository.allTaskItems().first;
       expect(tasks[0].name, '定期タスク'); // scheduledAt あり
@@ -204,28 +210,27 @@ void main() {
     });
 
     test('次回予定日がないタスクが複数あるとき全て末尾に集まる', () async {
-      await repository.addTask(
+      final idS = await repository.addTask(
         taskType: TaskType.scheduled,
         name: '定期タスク',
         icon: '📝',
         color: TaskColor.none,
         scheduleValue: 7,
         scheduleUnit: ScheduleUnit.day,
-        executedAt: DateTime(2025, 1, 1),
       );
+      await repository.recordExecution(idS, executedAt: DateTime(2025, 1, 1));
+
       await repository.addTask(
         taskType: TaskType.period,
         name: '不定期A',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
       await repository.addTask(
         taskType: TaskType.period,
         name: '不定期B',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
 
       final tasks = await repository.allTaskItems().first;
@@ -241,7 +246,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime.now(),
       );
       final tasks = await repository.allTaskItems().first;
 
@@ -251,7 +255,7 @@ void main() {
       expect(task.name, '散髪');
       expect(task.furigana, 'さんぱつ');
       expect(task.color, TaskColor.none);
-      expect(task.taskHistory, hasLength(1));
+      expect(task.taskHistory, isEmpty);
     });
 
     test('scheduled タスクを追加できる', () async {
@@ -262,7 +266,6 @@ void main() {
         color: TaskColor.orange,
         scheduleValue: 2,
         scheduleUnit: ScheduleUnit.week,
-        executedAt: DateTime.now(),
       );
       final tasks = await repository.allTaskItems().first;
 
@@ -272,7 +275,7 @@ void main() {
       expect(task.furigana, 'むしよけこうかん');
       expect(task.scheduleValue, 2);
       expect(task.scheduleUnit, ScheduleUnit.week);
-      expect(task.taskHistory, hasLength(1));
+      expect(task.taskHistory, isEmpty);
     });
 
     test('irregular タスクを追加できる', () async {
@@ -281,7 +284,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime.now(),
       );
       final tasks = await repository.allTaskItems().first;
 
@@ -299,7 +301,6 @@ void main() {
           name: '虫避け交換',
           icon: '📝',
           color: TaskColor.orange,
-          executedAt: DateTime.now(),
         ),
         throwsA(isA<TaskRepositoryException>()),
       );
@@ -313,7 +314,6 @@ void main() {
         name: '散髪',
         icon: '✂️',
         color: TaskColor.none,
-        executedAt: DateTime.now(),
       );
 
       final task = await repository.findTaskById(id);
@@ -331,7 +331,6 @@ void main() {
         color: TaskColor.orange,
         scheduleValue: 2,
         scheduleUnit: ScheduleUnit.week,
-        executedAt: DateTime.now(),
       );
 
       final task = await repository.findTaskById(id) as ScheduledTaskItem;
@@ -355,12 +354,11 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
       await repository.recordExecution(id, executedAt: DateTime(2025, 6, 1));
 
       final tasks = await repository.allTaskItems().first;
-      expect(tasks.first.taskHistory, hasLength(2));
+      expect(tasks.first.taskHistory, hasLength(1));
     });
 
     test('履歴が2件以上になると scheduledAt が算出される', () async {
@@ -369,8 +367,8 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
+      await repository.recordExecution(id, executedAt: DateTime(2025, 1, 1));
       await repository.recordExecution(id, executedAt: DateTime(2025, 2, 1));
 
       final tasks = await repository.allTaskItems().first;
@@ -383,7 +381,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
       final history = await repository.recordExecution(
         id,
@@ -399,7 +396,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
       final history = await repository.recordExecution(
         id,
@@ -417,7 +413,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
       final history = await repository.recordExecution(
         id,
@@ -434,7 +429,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
       final history = await repository.recordExecution(
         id,
@@ -457,7 +451,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
     });
 
@@ -548,7 +541,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime.now(),
       );
       await repository.updateTask(
         taskId: id,
@@ -574,7 +566,6 @@ void main() {
         color: TaskColor.orange,
         scheduleValue: 2,
         scheduleUnit: ScheduleUnit.week,
-        executedAt: DateTime.now(),
       );
       await repository.updateTask(
         taskId: id,
@@ -599,7 +590,6 @@ void main() {
         color: TaskColor.orange,
         scheduleValue: 2,
         scheduleUnit: ScheduleUnit.week,
-        executedAt: DateTime.now(),
       );
       await repository.updateTask(
         taskId: id,
@@ -619,7 +609,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime.now(),
       );
       await repository.updateTask(
         taskId: id,
@@ -645,7 +634,6 @@ void main() {
         color: TaskColor.orange,
         scheduleValue: 2,
         scheduleUnit: ScheduleUnit.week,
-        executedAt: DateTime.now(),
       );
 
       expect(
@@ -668,7 +656,6 @@ void main() {
         name: '散髪',
         icon: '✂️',
         color: TaskColor.none,
-        executedAt: DateTime.now(),
       );
 
       final task = await repository.watchTaskById(id).first;
@@ -688,7 +675,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime.now(),
       );
 
       final future = expectLater(
@@ -716,7 +702,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime.now(),
       );
 
       final future = expectLater(
@@ -737,14 +722,14 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
-      final history = await repository.recordExecution(
+      await repository.recordExecution(id, executedAt: DateTime(2025, 1, 1));
+      final target = await repository.recordExecution(
         id,
         executedAt: DateTime(2025, 6, 1),
       );
 
-      await repository.deleteExecution(history.id);
+      await repository.deleteExecution(target.id);
 
       final task = await repository.findTaskById(id);
       expect(task.taskHistory, hasLength(1));
@@ -757,7 +742,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
       await repository.recordExecution(id, executedAt: DateTime(2025, 3, 1));
       final target = await repository.recordExecution(
@@ -769,7 +753,7 @@ void main() {
       await repository.deleteExecution(target.id);
 
       final task = await repository.findTaskById(id);
-      expect(task.taskHistory, hasLength(3));
+      expect(task.taskHistory, hasLength(2));
       expect(
         task.taskHistory.map((h) => h.executedAt),
         isNot(contains(DateTime(2025, 6, 1))),
@@ -784,8 +768,8 @@ void main() {
         name: '散髪',
         icon: '✂️',
         color: TaskColor.none,
-        executedAt: DateTime(2025, 1, 1),
       );
+      await repository.recordExecution(id, executedAt: DateTime(2025, 1, 1));
       await repository.recordExecution(id, executedAt: DateTime(2025, 6, 1));
       final deleted = await repository.findTaskById(id);
       await repository.deleteTask(id);
@@ -809,7 +793,6 @@ void main() {
         color: TaskColor.orange,
         scheduleValue: 2,
         scheduleUnit: ScheduleUnit.week,
-        executedAt: DateTime.now(),
       );
       final deleted = await repository.findTaskById(id) as ScheduledTaskItem;
       await repository.deleteTask(id);
@@ -829,7 +812,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime.now(),
       );
       final deleted = await repository.findTaskById(id);
       await repository.deleteTask(id);
@@ -851,7 +833,6 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime.now(),
       );
       await repository.deleteTask(id);
 
@@ -865,14 +846,12 @@ void main() {
         name: '散髪',
         icon: '📝',
         color: TaskColor.none,
-        executedAt: DateTime.now(),
       );
       await repository.addTask(
         taskType: TaskType.period,
         name: '歯ブラシ交換',
         icon: '📝',
         color: TaskColor.blue,
-        executedAt: DateTime.now(),
       );
       await repository.deleteTask(id1);
 

--- a/test/data/repository/task/task_repository_test.dart
+++ b/test/data/repository/task/task_repository_test.dart
@@ -31,28 +31,6 @@ void main() {
 
   tearDown(() => db.close());
 
-  group('DBが異常な場合', () {
-    test('タスク一覧の取得がエラーになる', () async {
-      // DB に直接 scheduled タスクを挿入（taskScheduledConfigs なし）
-      await db
-          .into(db.taskDefinitions)
-          .insert(
-            TaskDefinitionsCompanion.insert(
-              taskType: TaskType.scheduled,
-              name: 'config なしタスク',
-              furigana: '',
-              icon: '📝',
-              color: TaskColor.none,
-            ),
-          );
-
-      await expectLater(
-        repository.allTaskItems(),
-        emitsError(isA<TaskNotFoundException>()),
-      );
-    });
-  });
-
   group('データベースエラー時の異常系', () {
     setUp(() async {
       await db.select(db.taskDefinitions).get();
@@ -151,91 +129,130 @@ void main() {
     });
   });
 
-  group('allTaskItems ソート順', () {
-    test('次回予定日が早いタスクが先に来る', () async {
-      // 後の scheduledAt を先に追加して、ソートで前に来ることを確認
-      final idB = await repository.addTask(
-        taskType: TaskType.scheduled,
-        name: 'タスクB',
-        icon: '📝',
-        color: TaskColor.none,
-        scheduleValue: 7,
-        scheduleUnit: ScheduleUnit.day,
-      );
-      await repository.recordExecution(
-        idB,
-        executedAt: DateTime(2025, 1, 15),
-      ); // scheduledAt = 1/22
+  group('allTaskItems', () {
+    group('DBが異常な場合', () {
+      setUp(() async {
+        await db
+            .into(db.taskDefinitions)
+            .insert(
+              TaskDefinitionsCompanion.insert(
+                taskType: TaskType.scheduled,
+                name: 'config なしタスク',
+                furigana: '',
+                icon: '📝',
+                color: TaskColor.none,
+              ),
+            );
+      });
 
-      final idA = await repository.addTask(
-        taskType: TaskType.scheduled,
-        name: 'タスクA',
-        icon: '📝',
-        color: TaskColor.none,
-        scheduleValue: 7,
-        scheduleUnit: ScheduleUnit.day,
-      );
-      await repository.recordExecution(
-        idA,
-        executedAt: DateTime(2025, 1, 1),
-      ); // scheduledAt = 1/8
-
-      final tasks = await repository.allTaskItems().first;
-      expect(tasks[0].name, 'タスクA'); // scheduledAt=1/8 が先
-      expect(tasks[1].name, 'タスクB'); // scheduledAt=1/22 が後
+      test('タスク一覧の取得がエラーになる', () async {
+        await expectLater(
+          repository.allTaskItems(),
+          emitsError(isA<TaskNotFoundException>()),
+        );
+      });
     });
 
-    test('次回予定日がないタスクは末尾に来る', () async {
-      // PeriodTask 履歴0件 → scheduledAt=null
-      await repository.addTask(
-        taskType: TaskType.period,
-        name: '不定期タスク',
-        icon: '📝',
-        color: TaskColor.none,
-      );
+    group('ソート順', () {
+      group('次回予定日が異なる場合', () {
+        setUp(() async {
+          final idB = await repository.addTask(
+            taskType: TaskType.scheduled,
+            name: 'タスクB',
+            icon: '📝',
+            color: TaskColor.none,
+            scheduleValue: 7,
+            scheduleUnit: ScheduleUnit.day,
+          );
+          await repository.recordExecution(
+            idB,
+            executedAt: DateTime(2025, 1, 15),
+          ); // scheduledAt = 1/22
 
-      final idS = await repository.addTask(
-        taskType: TaskType.scheduled,
-        name: '定期タスク',
-        icon: '📝',
-        color: TaskColor.none,
-        scheduleValue: 7,
-        scheduleUnit: ScheduleUnit.day,
-      );
-      await repository.recordExecution(idS, executedAt: DateTime(2025, 1, 1));
+          final idA = await repository.addTask(
+            taskType: TaskType.scheduled,
+            name: 'タスクA',
+            icon: '📝',
+            color: TaskColor.none,
+            scheduleValue: 7,
+            scheduleUnit: ScheduleUnit.day,
+          );
+          await repository.recordExecution(
+            idA,
+            executedAt: DateTime(2025, 1, 1),
+          ); // scheduledAt = 1/8
+        });
 
-      final tasks = await repository.allTaskItems().first;
-      expect(tasks[0].name, '定期タスク'); // scheduledAt あり
-      expect(tasks[1].name, '不定期タスク'); // scheduledAt=null → 末尾
-    });
+        test('次回予定日が早いタスクが先に来る', () async {
+          final tasks = await repository.allTaskItems().first;
+          expect(tasks[0].name, 'タスクA');
+          expect(tasks[1].name, 'タスクB');
+        });
+      });
 
-    test('次回予定日がないタスクが複数あるとき全て末尾に集まる', () async {
-      final idS = await repository.addTask(
-        taskType: TaskType.scheduled,
-        name: '定期タスク',
-        icon: '📝',
-        color: TaskColor.none,
-        scheduleValue: 7,
-        scheduleUnit: ScheduleUnit.day,
-      );
-      await repository.recordExecution(idS, executedAt: DateTime(2025, 1, 1));
+      group('次回予定日がないタスクが混在する場合', () {
+        setUp(() async {
+          await repository.addTask(
+            taskType: TaskType.period,
+            name: '不定期タスク',
+            icon: '📝',
+            color: TaskColor.none,
+          );
+          final idS = await repository.addTask(
+            taskType: TaskType.scheduled,
+            name: '定期タスク',
+            icon: '📝',
+            color: TaskColor.none,
+            scheduleValue: 7,
+            scheduleUnit: ScheduleUnit.day,
+          );
+          await repository.recordExecution(
+            idS,
+            executedAt: DateTime(2025, 1, 1),
+          );
+        });
 
-      await repository.addTask(
-        taskType: TaskType.period,
-        name: '不定期A',
-        icon: '📝',
-        color: TaskColor.none,
-      );
-      await repository.addTask(
-        taskType: TaskType.period,
-        name: '不定期B',
-        icon: '📝',
-        color: TaskColor.none,
-      );
+        test('次回予定日がないタスクは末尾に来る', () async {
+          final tasks = await repository.allTaskItems().first;
+          expect(tasks[0].name, '定期タスク');
+          expect(tasks[1].name, '不定期タスク');
+        });
+      });
 
-      final tasks = await repository.allTaskItems().first;
-      expect(tasks[0].name, '定期タスク');
-      expect(tasks.skip(1).map((t) => t.name).toSet(), {'不定期A', '不定期B'});
+      group('次回予定日がないタスクが複数ある場合', () {
+        setUp(() async {
+          final idS = await repository.addTask(
+            taskType: TaskType.scheduled,
+            name: '定期タスク',
+            icon: '📝',
+            color: TaskColor.none,
+            scheduleValue: 7,
+            scheduleUnit: ScheduleUnit.day,
+          );
+          await repository.recordExecution(
+            idS,
+            executedAt: DateTime(2025, 1, 1),
+          );
+          await repository.addTask(
+            taskType: TaskType.period,
+            name: '不定期A',
+            icon: '📝',
+            color: TaskColor.none,
+          );
+          await repository.addTask(
+            taskType: TaskType.period,
+            name: '不定期B',
+            icon: '📝',
+            color: TaskColor.none,
+          );
+        });
+
+        test('全て末尾に集まる', () async {
+          final tasks = await repository.allTaskItems().first;
+          expect(tasks[0].name, '定期タスク');
+          expect(tasks.skip(1).map((t) => t.name).toSet(), {'不定期A', '不定期B'});
+        });
+      });
     });
   });
 

--- a/test/helpers/fake_task_repository.dart
+++ b/test/helpers/fake_task_repository.dart
@@ -51,7 +51,6 @@ class FakeTaskRepository implements TaskRepository {
     required String name,
     required String icon,
     required TaskColor color,
-    required DateTime executedAt,
     int? scheduleValue,
     ScheduleUnit? scheduleUnit,
   }) async {


### PR DESCRIPTION
## 概要

- タスク新規作成時にその日にタスクを実行したものとして登録を行っていた
- 定義だけ追加したいという方が自然なので実行履歴の登録を行わないように修正
- 実行履歴が空になるケースの影響については #81 などですでに対応済み

---
closes #76 