### PR TITLE
通知機能の実装

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,6 +18,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
 
     defaultConfig {
@@ -29,6 +30,7 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        multiDexEnabled = true
     }
 
     buildTypes {
@@ -51,5 +53,6 @@ flutter {
 }
 
 dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
     implementation("com.atilika.kuromoji:kuromoji-ipadic:0.9.0")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+
     <application
         android:label="dawnbreaker"
         android:name="${applicationName}"
@@ -25,6 +29,20 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <receiver
+            android:exported="false"
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"/>
+        <receiver
+            android:exported="false"
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.QUICKBOOT_POWERON"/>
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+            </intent-filter>
+        </receiver>
+
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,6 +2,12 @@ PODS:
   - emoji_picker_flutter (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - flutter_local_notifications (0.0.1):
+    - Flutter
+  - integration_test (0.0.1):
+    - Flutter
+  - package_info_plus (0.4.5):
+    - Flutter
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -34,6 +40,9 @@ PODS:
 DEPENDENCIES:
   - emoji_picker_flutter (from `.symlinks/plugins/emoji_picker_flutter/ios`)
   - Flutter (from `Flutter`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
+  - integration_test (from `.symlinks/plugins/integration_test/ios`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
 
@@ -46,6 +55,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/emoji_picker_flutter/ios"
   Flutter:
     :path: Flutter
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
+  integration_test:
+    :path: ".symlinks/plugins/integration_test/ios"
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqlite3_flutter_libs:
@@ -54,6 +69,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   emoji_picker_flutter: 8e50ec5caac456a23a78637e02c6293ea0ac8771
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_local_notifications: eda81afddbf18f8589f6ec069ce593c4c6378769
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
   shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
   sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
   sqlite3_flutter_libs: f9114e4bbe1f2e03dd543373c53d23245982ca13

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,7 @@
 import Flutter
 import UIKit
+import UserNotifications
+import flutter_local_notifications
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
@@ -7,11 +9,15 @@ import UIKit
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
     
     func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
         GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
         FuriganaTranslate.register(with: engineBridge.pluginRegistry.registrar(forPlugin: "FuriganaTranslate")!)
+        FlutterLocalNotificationsPlugin.setPluginRegistrantCallback { registry in
+            GeneratedPluginRegistrant.register(with: registry)
+        }
     }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,6 +49,11 @@
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,36 +1,22 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_router.dart';
 import 'package:dawnbreaker/app/app_theme.dart';
-import 'package:dawnbreaker/core/notification/notification_service_impl.dart';
 import 'package:dawnbreaker/core/util/context_extension.dart';
 import 'package:dawnbreaker/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class App extends ConsumerStatefulWidget {
+class App extends ConsumerWidget {
   const App({super.key});
 
   @override
-  ConsumerState<App> createState() => _AppState();
-}
-
-class _AppState extends ConsumerState<App> {
-  var _channelsSetup = false;
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final appRouter = ref.read(appRouterProvider);
-    final notificationService = ref.read(notificationServiceProvider);
     return MaterialApp.router(
       onGenerateTitle: (context) => context.l10n.title,
-      builder: (context, child) {
-        if (!_channelsSetup) {
-          _channelsSetup = true;
-          notificationService.setupChannels(context);
-        }
-        return ColoredBox(color: context.appColorScheme.bg, child: child!);
-      },
+      builder: (context, child) =>
+          ColoredBox(color: context.appColorScheme.bg, child: child!),
       theme: createThemeData(context),
       localizationsDelegates: const [
         AppLocalizations.delegate,

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,22 +1,36 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_router.dart';
 import 'package:dawnbreaker/app/app_theme.dart';
+import 'package:dawnbreaker/core/notification/notification_service_impl.dart';
 import 'package:dawnbreaker/core/util/context_extension.dart';
 import 'package:dawnbreaker/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class App extends ConsumerWidget {
+class App extends ConsumerStatefulWidget {
   const App({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<App> createState() => _AppState();
+}
+
+class _AppState extends ConsumerState<App> {
+  var _channelsSetup = false;
+
+  @override
+  Widget build(BuildContext context) {
     final appRouter = ref.read(appRouterProvider);
+    final notificationService = ref.read(notificationServiceProvider);
     return MaterialApp.router(
       onGenerateTitle: (context) => context.l10n.title,
-      builder: (context, child) =>
-          ColoredBox(color: context.appColorScheme.bg, child: child!),
+      builder: (context, child) {
+        if (!_channelsSetup) {
+          _channelsSetup = true;
+          notificationService.setupChannels(context);
+        }
+        return ColoredBox(color: context.appColorScheme.bg, child: child!);
+      },
       theme: createThemeData(context),
       localizationsDelegates: const [
         AppLocalizations.delegate,

--- a/lib/core/notification/notification_service.dart
+++ b/lib/core/notification/notification_service.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/widgets.dart';
+
+abstract interface class NotificationService {
+  Future<void> initialize();
+
+  Future<void> setupChannels(BuildContext context);
+
+  Future<void> requestPermission();
+}

--- a/lib/core/notification/notification_service.dart
+++ b/lib/core/notification/notification_service.dart
@@ -1,10 +1,7 @@
 import 'package:dawnbreaker/data/model/task_item.dart';
-import 'package:flutter/widgets.dart';
 
 abstract interface class NotificationService {
   Future<void> initialize();
-
-  Future<void> setupChannels(BuildContext context);
 
   Future<void> requestPermission();
 

--- a/lib/core/notification/notification_service.dart
+++ b/lib/core/notification/notification_service.dart
@@ -1,3 +1,4 @@
+import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:flutter/widgets.dart';
 
 abstract interface class NotificationService {
@@ -6,4 +7,8 @@ abstract interface class NotificationService {
   Future<void> setupChannels(BuildContext context);
 
   Future<void> requestPermission();
+
+  Future<void> registerNotification(TaskItem task);
+
+  Future<void> removeNotification(TaskItem task);
 }

--- a/lib/core/notification/notification_service_impl.dart
+++ b/lib/core/notification/notification_service_impl.dart
@@ -124,13 +124,13 @@ class NotificationServiceImpl implements NotificationService {
       title: task.name,
       body: _l10n.notificationTaskBody,
       scheduledDate: notifyAt,
-      notificationDetails: const NotificationDetails(
+      notificationDetails: NotificationDetails(
         android: AndroidNotificationDetails(
           taskChannelId,
-          taskChannelId,
+          _l10n.notificationChannelTask,
           importance: Importance.high,
         ),
-        iOS: DarwinNotificationDetails(),
+        iOS: const DarwinNotificationDetails(),
       ),
       androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
       payload: task.id.toString(),

--- a/lib/core/notification/notification_service_impl.dart
+++ b/lib/core/notification/notification_service_impl.dart
@@ -2,9 +2,11 @@ import 'dart:io';
 
 import 'package:dawnbreaker/core/notification/notification_service.dart';
 import 'package:dawnbreaker/core/util/context_extension.dart';
+import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:timezone/timezone.dart' as tz;
 
 part 'notification_service_impl.g.dart';
 
@@ -84,6 +86,53 @@ class NotificationServiceImpl implements NotificationService {
         sound: true,
       );
     }
+  }
+
+  static const _notifyHour = 9;
+  static const _notificationBody = '予定日になりました';
+
+  @override
+  Future<void> registerNotification(TaskItem task) async {
+    final scheduledAt = task.scheduledAt;
+    if (scheduledAt == null) {
+      await removeNotification(task);
+      return;
+    }
+
+    final notifyAt = tz.TZDateTime(
+      tz.local,
+      scheduledAt.year,
+      scheduledAt.month,
+      scheduledAt.day,
+      _notifyHour,
+    );
+    if (notifyAt.isBefore(tz.TZDateTime.now(tz.local))) {
+      await removeNotification(task);
+      return;
+    }
+
+    await _plugin.cancel(id: task.id);
+    await _plugin.zonedSchedule(
+      id: task.id,
+      title: task.name,
+      body: _notificationBody,
+      scheduledDate: notifyAt,
+      notificationDetails: const NotificationDetails(
+        android: AndroidNotificationDetails(
+          taskChannelId,
+          taskChannelId,
+          importance: Importance.high,
+        ),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
+      payload: task.id.toString(),
+    );
+  }
+
+  @override
+  Future<void> removeNotification(TaskItem task) async {
+    await _plugin.cancel(id: task.id);
   }
 
   void _onNotificationResponse(NotificationResponse details) {

--- a/lib/core/notification/notification_service_impl.dart
+++ b/lib/core/notification/notification_service_impl.dart
@@ -1,0 +1,92 @@
+import 'dart:io';
+
+import 'package:dawnbreaker/core/notification/notification_service.dart';
+import 'package:dawnbreaker/core/util/context_extension.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notification_service_impl.g.dart';
+
+@pragma('vm:entry-point')
+void onDidReceiveBackgroundNotificationResponse(NotificationResponse details) {
+  // TODO: バックグラウンド・アプリキル状態で受け取った通知のハンドリングを行う
+}
+
+@Riverpod(keepAlive: true)
+NotificationService notificationService(Ref ref) => NotificationServiceImpl();
+
+const _taskGroupId = 'task_notifications';
+const taskChannelId = 'individual_task_notification';
+
+class NotificationServiceImpl implements NotificationService {
+  static const _androidSettings = AndroidInitializationSettings(
+    '@mipmap/ic_launcher',
+  );
+
+  static const _iosSettings = DarwinInitializationSettings(
+    requestAlertPermission: false,
+    requestBadgePermission: false,
+    requestSoundPermission: false,
+  );
+
+  final _plugin = FlutterLocalNotificationsPlugin();
+
+  AndroidFlutterLocalNotificationsPlugin? get _androidImplementation => _plugin
+      .resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin
+      >();
+
+  IOSFlutterLocalNotificationsPlugin? get _iOSImplementation => _plugin
+      .resolvePlatformSpecificImplementation<
+        IOSFlutterLocalNotificationsPlugin
+      >();
+
+  @override
+  Future<void> initialize() async {
+    const settings = InitializationSettings(
+      android: _androidSettings,
+      iOS: _iosSettings,
+    );
+    await _plugin.initialize(
+      settings: settings,
+      onDidReceiveNotificationResponse: _onNotificationResponse,
+      onDidReceiveBackgroundNotificationResponse:
+          onDidReceiveBackgroundNotificationResponse,
+    );
+  }
+
+  @override
+  Future<void> setupChannels(BuildContext context) async {
+    if (!Platform.isAndroid) return;
+    final l10n = context.l10n;
+    await _androidImplementation?.createNotificationChannelGroup(
+      AndroidNotificationChannelGroup(_taskGroupId, l10n.notificationGroupTask),
+    );
+    await _androidImplementation?.createNotificationChannel(
+      AndroidNotificationChannel(
+        taskChannelId,
+        l10n.notificationChannelTask,
+        groupId: _taskGroupId,
+        importance: Importance.high,
+      ),
+    );
+  }
+
+  @override
+  Future<void> requestPermission() async {
+    if (Platform.isAndroid) {
+      await _androidImplementation?.requestNotificationsPermission();
+    } else if (Platform.isIOS) {
+      await _iOSImplementation?.requestPermissions(
+        alert: true,
+        badge: true,
+        sound: true,
+      );
+    }
+  }
+
+  void _onNotificationResponse(NotificationResponse details) {
+    // TODO: フォアグラウンドで通知を受け取ったときの処理を行う
+  }
+}

--- a/lib/core/notification/notification_service_impl.dart
+++ b/lib/core/notification/notification_service_impl.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
 
 import 'package:dawnbreaker/core/notification/notification_service.dart';
-import 'package:dawnbreaker/core/util/context_extension.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
-import 'package:flutter/widgets.dart';
+import 'package:dawnbreaker/l10n/app_localizations.dart';
+import 'package:dawnbreaker/l10n/app_localizations_provider.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:timezone/timezone.dart' as tz;
@@ -16,12 +16,20 @@ void onDidReceiveBackgroundNotificationResponse(NotificationResponse details) {
 }
 
 @Riverpod(keepAlive: true)
-NotificationService notificationService(Ref ref) => NotificationServiceImpl();
+Future<NotificationService> notificationService(Ref ref) async {
+  final appLocalizations = await ref.watch(appLocalizationsProvider.future);
+  return NotificationServiceImpl(localizations: appLocalizations);
+}
 
 const _taskGroupId = 'task_notifications';
 const taskChannelId = 'individual_task_notification';
 
 class NotificationServiceImpl implements NotificationService {
+  NotificationServiceImpl({required AppLocalizations localizations})
+    : _l10n = localizations;
+
+  final AppLocalizations _l10n;
+
   static const _androidSettings = AndroidInitializationSettings(
     '@mipmap/ic_launcher',
   );
@@ -56,23 +64,23 @@ class NotificationServiceImpl implements NotificationService {
       onDidReceiveBackgroundNotificationResponse:
           onDidReceiveBackgroundNotificationResponse,
     );
-  }
 
-  @override
-  Future<void> setupChannels(BuildContext context) async {
-    if (!Platform.isAndroid) return;
-    final l10n = context.l10n;
-    await _androidImplementation?.createNotificationChannelGroup(
-      AndroidNotificationChannelGroup(_taskGroupId, l10n.notificationGroupTask),
-    );
-    await _androidImplementation?.createNotificationChannel(
-      AndroidNotificationChannel(
-        taskChannelId,
-        l10n.notificationChannelTask,
-        groupId: _taskGroupId,
-        importance: Importance.high,
-      ),
-    );
+    if (Platform.isAndroid) {
+      await _androidImplementation?.createNotificationChannelGroup(
+        AndroidNotificationChannelGroup(
+          _taskGroupId,
+          _l10n.notificationGroupTask,
+        ),
+      );
+      await _androidImplementation?.createNotificationChannel(
+        AndroidNotificationChannel(
+          taskChannelId,
+          _l10n.notificationChannelTask,
+          groupId: _taskGroupId,
+          importance: Importance.high,
+        ),
+      );
+    }
   }
 
   @override
@@ -89,7 +97,6 @@ class NotificationServiceImpl implements NotificationService {
   }
 
   static const _notifyHour = 9;
-  static const _notificationBody = '予定日になりました';
 
   @override
   Future<void> registerNotification(TaskItem task) async {
@@ -115,7 +122,7 @@ class NotificationServiceImpl implements NotificationService {
     await _plugin.zonedSchedule(
       id: task.id,
       title: task.name,
-      body: _notificationBody,
+      body: _l10n.notificationTaskBody,
       scheduledDate: notifyAt,
       notificationDetails: const NotificationDetails(
         android: AndroidNotificationDetails(

--- a/lib/core/notification/task_notification_sync.dart
+++ b/lib/core/notification/task_notification_sync.dart
@@ -1,0 +1,61 @@
+import 'package:collection/collection.dart';
+import 'package:dawnbreaker/core/notification/notification_service.dart';
+import 'package:dawnbreaker/core/notification/notification_service_impl.dart';
+import 'package:dawnbreaker/data/model/task_item.dart';
+import 'package:dawnbreaker/data/repository/task/task_repository_impl.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'task_notification_sync.g.dart';
+
+/// すべてのタスクを監視して変化があったときに通知を登録する
+@Riverpod(keepAlive: true)
+class TaskNotificationSync extends _$TaskNotificationSync {
+  @override
+  void build() {
+    final repository = ref.read(taskRepositoryProvider);
+    final service = ref.read(notificationServiceProvider);
+
+    final sub = repository
+        .allTaskItems()
+        .distinct(
+          (prev, curr) => const IterableEquality<TaskItem>().equals(prev, curr),
+        )
+        .pairwise(initialValue: [])
+        .listen((pair) {
+          _updateNotifications(service, previous: pair.$1, current: pair.$2);
+        });
+
+    ref.onDispose(sub.cancel);
+  }
+
+  void _updateNotifications(
+    NotificationService service, {
+    required List<TaskItem> previous,
+    required List<TaskItem> current,
+  }) {
+    final previousSet = previous.toSet();
+    final currentSet = current.toSet();
+
+    for (final task in previousSet.difference(currentSet)) {
+      service.removeNotification(task);
+    }
+
+    for (final task in currentSet.difference(previousSet)) {
+      if (task.scheduledAt != null) {
+        service.registerNotification(task);
+      } else {
+        service.removeNotification(task);
+      }
+    }
+  }
+}
+
+extension _PairwiseExtension<T> on Stream<T> {
+  Stream<(T, T)> pairwise({required T initialValue}) async* {
+    var prev = initialValue;
+    await for (final element in this) {
+      yield (prev, element);
+      prev = element;
+    }
+  }
+}

--- a/lib/core/notification/task_notification_sync.dart
+++ b/lib/core/notification/task_notification_sync.dart
@@ -12,9 +12,9 @@ part 'task_notification_sync.g.dart';
 @Riverpod(keepAlive: true)
 class TaskNotificationSync extends _$TaskNotificationSync {
   @override
-  void build() {
+  Future<void> build() async {
     final repository = ref.read(taskRepositoryProvider);
-    final service = ref.read(notificationServiceProvider);
+    final service = await ref.read(notificationServiceProvider.future);
 
     final sub = repository
         .allTaskItems()

--- a/lib/core/notification/task_notification_sync.dart
+++ b/lib/core/notification/task_notification_sync.dart
@@ -3,6 +3,7 @@ import 'package:dawnbreaker/core/notification/notification_service.dart';
 import 'package:dawnbreaker/core/notification/notification_service_impl.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository_impl.dart';
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'task_notification_sync.g.dart';
@@ -22,30 +23,31 @@ class TaskNotificationSync extends _$TaskNotificationSync {
         )
         .pairwise(initialValue: [])
         .listen((pair) {
-          _updateNotifications(service, previous: pair.$1, current: pair.$2);
+          updateNotifications(service, previous: pair.$1, current: pair.$2);
         });
 
     ref.onDispose(sub.cancel);
   }
+}
 
-  void _updateNotifications(
-    NotificationService service, {
-    required List<TaskItem> previous,
-    required List<TaskItem> current,
-  }) {
-    final previousSet = previous.toSet();
-    final currentSet = current.toSet();
+@visibleForTesting
+void updateNotifications(
+  NotificationService service, {
+  required List<TaskItem> previous,
+  required List<TaskItem> current,
+}) {
+  final previousSet = previous.toSet();
+  final currentSet = current.toSet();
 
-    for (final task in previousSet.difference(currentSet)) {
+  for (final task in previousSet.difference(currentSet)) {
+    service.removeNotification(task);
+  }
+
+  for (final task in currentSet.difference(previousSet)) {
+    if (task.scheduledAt != null) {
+      service.registerNotification(task);
+    } else {
       service.removeNotification(task);
-    }
-
-    for (final task in currentSet.difference(previousSet)) {
-      if (task.scheduledAt != null) {
-        service.registerNotification(task);
-      } else {
-        service.removeNotification(task);
-      }
     }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -193,5 +193,7 @@
   "settingsDebugGenerateDummyTasks": "Generate dummy tasks",
   "settingsDebugDummyTasksGenerated": "Dummy tasks generated",
   "settingsDebugDeleteAllTasks": "Delete all tasks",
-  "settingsDebugAllTasksDeleted": "All tasks deleted"
+  "settingsDebugAllTasksDeleted": "All tasks deleted",
+  "notificationGroupTask": "Task Notifications",
+  "notificationChannelTask": "Individual Task Notification"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -195,5 +195,6 @@
   "settingsDebugDeleteAllTasks": "Delete all tasks",
   "settingsDebugAllTasksDeleted": "All tasks deleted",
   "notificationGroupTask": "Task Notifications",
-  "notificationChannelTask": "Individual Task Notification"
+  "notificationChannelTask": "Individual Task Notification",
+  "notificationTaskBody": "It's due today"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -195,5 +195,6 @@
   "settingsDebugDeleteAllTasks": "すべてのタスクを削除",
   "settingsDebugAllTasksDeleted": "すべてのタスクを削除しました",
   "notificationGroupTask": "タスク通知",
-  "notificationChannelTask": "個別タスク通知"
+  "notificationChannelTask": "個別タスク通知",
+  "notificationTaskBody": "予定日になりました"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -193,5 +193,7 @@
   "settingsDebugGenerateDummyTasks": "ダミータスクを生成",
   "settingsDebugDummyTasksGenerated": "ダミータスクを生成しました",
   "settingsDebugDeleteAllTasks": "すべてのタスクを削除",
-  "settingsDebugAllTasksDeleted": "すべてのタスクを削除しました"
+  "settingsDebugAllTasksDeleted": "すべてのタスクを削除しました",
+  "notificationGroupTask": "タスク通知",
+  "notificationChannelTask": "個別タスク通知"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -757,6 +757,12 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'個別タスク通知'**
   String get notificationChannelTask;
+
+  /// No description provided for @notificationTaskBody.
+  ///
+  /// In ja, this message translates to:
+  /// **'予定日になりました'**
+  String get notificationTaskBody;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -745,6 +745,18 @@ abstract class AppLocalizations {
   /// In ja, this message translates to:
   /// **'すべてのタスクを削除しました'**
   String get settingsDebugAllTasksDeleted;
+
+  /// No description provided for @notificationGroupTask.
+  ///
+  /// In ja, this message translates to:
+  /// **'タスク通知'**
+  String get notificationGroupTask;
+
+  /// No description provided for @notificationChannelTask.
+  ///
+  /// In ja, this message translates to:
+  /// **'個別タスク通知'**
+  String get notificationChannelTask;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -365,4 +365,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get notificationChannelTask => 'Individual Task Notification';
+
+  @override
+  String get notificationTaskBody => 'It\'s due today';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -359,4 +359,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsDebugAllTasksDeleted => 'All tasks deleted';
+
+  @override
+  String get notificationGroupTask => 'Task Notifications';
+
+  @override
+  String get notificationChannelTask => 'Individual Task Notification';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -354,4 +354,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get settingsDebugAllTasksDeleted => 'すべてのタスクを削除しました';
+
+  @override
+  String get notificationGroupTask => 'タスク通知';
+
+  @override
+  String get notificationChannelTask => '個別タスク通知';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -360,4 +360,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get notificationChannelTask => '個別タスク通知';
+
+  @override
+  String get notificationTaskBody => '予定日になりました';
 }

--- a/lib/l10n/app_localizations_provider.dart
+++ b/lib/l10n/app_localizations_provider.dart
@@ -1,0 +1,41 @@
+import 'package:dawnbreaker/l10n/app_localizations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'app_localizations_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class AppLocalizationsNotifier extends _$AppLocalizationsNotifier {
+  @override
+  Future<AppLocalizations> build() async {
+    final binding = WidgetsBinding.instance;
+
+    final observer = _LocaleObserver(() async {
+      state = await AsyncValue.guard(() => _load());
+    });
+
+    binding.addObserver(observer);
+    ref.onDispose(() => binding.removeObserver(observer));
+
+    return await _load();
+  }
+
+  Future<AppLocalizations> _load() async {
+    final locale = WidgetsBinding.instance.platformDispatcher.locale;
+    final supportedLocale = basicLocaleListResolution([
+      locale,
+    ], AppLocalizations.supportedLocales);
+    return await AppLocalizations.delegate.load(supportedLocale);
+  }
+}
+
+class _LocaleObserver extends WidgetsBindingObserver {
+  _LocaleObserver(this._onChanged);
+
+  final VoidCallback _onChanged;
+
+  @override
+  void didChangeLocales(List<Locale>? locales) {
+    _onChanged();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:dawnbreaker/app/app.dart';
 import 'package:dawnbreaker/core/notification/notification_service_impl.dart';
 import 'package:dawnbreaker/core/notification/task_notification_sync.dart';
 import 'package:dawnbreaker/data/preferences/shared_preferences_provider.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -12,11 +12,13 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initializeDateFormatting();
   tz.initializeTimeZones();
+
   final preferences = await SharedPreferences.getInstance();
   final container = ProviderContainer(
     overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
   );
-  await container.read(notificationServiceProvider).initialize();
+  final notificationService = await container.read(notificationServiceProvider.future);
+  await notificationService.initialize();
   container.read(taskNotificationSyncProvider);
 
   runApp(UncontrolledProviderScope(container: container, child: const App()));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:dawnbreaker/app/app.dart';
+import 'package:dawnbreaker/core/notification/notification_service_impl.dart';
 import 'package:dawnbreaker/data/preferences/shared_preferences_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -12,6 +13,7 @@ void main() async {
   final container = ProviderContainer(
     overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
   );
+  await container.read(notificationServiceProvider).initialize();
 
   runApp(UncontrolledProviderScope(container: container, child: const App()));
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,19 +1,23 @@
 import 'package:dawnbreaker/app/app.dart';
 import 'package:dawnbreaker/core/notification/notification_service_impl.dart';
+import 'package:dawnbreaker/core/notification/task_notification_sync.dart';
 import 'package:dawnbreaker/data/preferences/shared_preferences_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:timezone/data/latest.dart' as tz;
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initializeDateFormatting();
+  tz.initializeTimeZones();
   final preferences = await SharedPreferences.getInstance();
   final container = ProviderContainer(
     overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
   );
   await container.read(notificationServiceProvider).initialize();
+  container.read(taskNotificationSyncProvider);
 
   runApp(UncontrolledProviderScope(container: container, child: const App()));
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -257,6 +257,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.4.0"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -365,6 +373,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: e8d63f50f2806a3a71a08697286a0369e1d8f0902961327810459871c0bb01c2
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -1034,7 +1050,7 @@ packages:
     source: hosted
     version: "0.6.16"
   timezone:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: timezone
       sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -217,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   drift:
     dependency: "direct main"
     description:
@@ -307,6 +315,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "21.0.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -652,6 +692,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -985,6 +1033,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.16"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.0"
   typed_data:
     dependency: transitive
     description:
@@ -1081,6 +1137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   smooth_page_indicator: ^2.0.1
   shared_preferences: ^2.3.5
   package_info_plus: ^10.1.0
+  flutter_local_notifications: ^21.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   shared_preferences: ^2.3.5
   package_info_plus: ^10.1.0
   flutter_local_notifications: ^21.0.0
+  flutter_timezone: ^5.0.2
+  timezone: ^0.11.0
 
 dev_dependencies:
   flutter_test:

--- a/test/core/notification/task_notification_sync_test.dart
+++ b/test/core/notification/task_notification_sync_test.dart
@@ -1,0 +1,132 @@
+import 'package:dawnbreaker/core/notification/task_notification_sync.dart';
+import 'package:dawnbreaker/core/util/date_util.dart';
+import 'package:dawnbreaker/data/model/schedule_unit.dart';
+import 'package:dawnbreaker/data/model/task_color.dart';
+import 'package:dawnbreaker/data/model/task_history.dart';
+import 'package:dawnbreaker/data/model/task_item.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../helpers/fake_notification_service.dart';
+
+void main() {
+  late FakeNotificationService service;
+
+  setUp(() {
+    service = FakeNotificationService();
+  });
+
+  group('updateNotifications', () {
+    group('タスク追加', () {
+      test('scheduledAt があるタスクは通知が登録される', () {
+        final task = _makeScheduled(id: 1);
+        updateNotifications(service, previous: [], current: [task]);
+
+        expect(service.registered, [task]);
+        expect(service.removed, isEmpty);
+      });
+
+      test('scheduledAt がないタスクは通知が削除される', () {
+        final task = _makeIrregular(id: 1);
+        updateNotifications(service, previous: [], current: [task]);
+
+        expect(service.registered, isEmpty);
+        expect(service.removed, [task]);
+      });
+
+      test('scheduledAt ありとなしが混在する場合に正しく分類される', () {
+        final s1 = _makeScheduled(id: 1);
+        final s2 = _makeScheduled(id: 2);
+        final i1 = _makeIrregular(id: 3);
+        final i2 = _makeIrregular(id: 4);
+        updateNotifications(service, previous: [], current: [s1, s2, i1, i2]);
+
+        expect(service.registered, containsAll([s1, s2]));
+        expect(service.removed, containsAll([i1, i2]));
+      });
+    });
+
+    group('タスク削除', () {
+      test('削除されたタスクの通知が削除される', () {
+        final task = _makeScheduled(id: 1);
+        updateNotifications(service, previous: [task], current: []);
+
+        expect(service.removed, [task]);
+        expect(service.registered, isEmpty);
+      });
+
+      test('複数タスクのうち一部だけ削除された場合、削除分のみ解除される', () {
+        final keep = _makeScheduled(id: 1);
+        final remove = _makeScheduled(id: 2);
+        updateNotifications(service, previous: [keep, remove], current: [keep]);
+
+        expect(service.removed, [remove]);
+        expect(service.registered, isEmpty);
+      });
+    });
+
+    group('タスク更新', () {
+      test('スケジュールが変わったタスクは旧通知が削除されて新通知が登録される', () {
+        final old = _makeScheduled(id: 1, scheduleValue: 7);
+        final updated = _makeScheduled(id: 1, scheduleValue: 14);
+        updateNotifications(service, previous: [old], current: [updated]);
+
+        expect(service.removed, [old]);
+        expect(service.registered, [updated]);
+      });
+
+      test('変更されたタスクと変更されていないタスクが混在する場合、変更分のみ処理される', () {
+        final unchanged = _makeScheduled(id: 1);
+        final old = _makeScheduled(id: 2, scheduleValue: 7);
+        final updated = _makeScheduled(id: 2, scheduleValue: 14);
+        updateNotifications(
+          service,
+          previous: [unchanged, old],
+          current: [unchanged, updated],
+        );
+
+        expect(service.removed, [old]);
+        expect(service.registered, [updated]);
+      });
+    });
+
+    group('変化なし', () {
+      test('同じリストを渡した場合、通知メソッドは呼ばれない', () {
+        final tasks = [_makeScheduled(id: 1), _makeScheduled(id: 2)];
+        updateNotifications(service, previous: tasks, current: tasks);
+
+        expect(service.registered, isEmpty);
+        expect(service.removed, isEmpty);
+      });
+    });
+  });
+}
+
+TaskItem _makeScheduled({
+  required int id,
+  int scheduleValue = 7,
+  int daysAgo = 7,
+}) => TaskItem.scheduled(
+  id: id,
+  name: 'タスク$id',
+  furigana: '',
+  icon: '📝',
+  color: TaskColor.none,
+  scheduleValue: scheduleValue,
+  scheduleUnit: ScheduleUnit.day,
+  taskHistory: [
+    TaskHistory(
+      id: id * 10,
+      executedAt: DateTime.now().truncateTime.subtract(Duration(days: daysAgo)),
+      comment: null,
+    ),
+  ],
+);
+
+TaskItem _makeIrregular({required int id}) => TaskItem.irregular(
+  id: id,
+  name: 'タスク$id',
+  furigana: '',
+  icon: '📝',
+  color: TaskColor.none,
+  taskHistory: [],
+);

--- a/test/helpers/fake_notification_service.dart
+++ b/test/helpers/fake_notification_service.dart
@@ -1,6 +1,5 @@
 import 'package:dawnbreaker/core/notification/notification_service.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
-import 'package:flutter/widgets.dart';
 
 class FakeNotificationService implements NotificationService {
   final List<TaskItem> registered = [];
@@ -8,9 +7,6 @@ class FakeNotificationService implements NotificationService {
 
   @override
   Future<void> initialize() async {}
-
-  @override
-  Future<void> setupChannels(BuildContext context) async {}
 
   @override
   Future<void> requestPermission() async {}

--- a/test/helpers/fake_notification_service.dart
+++ b/test/helpers/fake_notification_service.dart
@@ -1,0 +1,24 @@
+import 'package:dawnbreaker/core/notification/notification_service.dart';
+import 'package:dawnbreaker/data/model/task_item.dart';
+import 'package:flutter/widgets.dart';
+
+class FakeNotificationService implements NotificationService {
+  final List<TaskItem> registered = [];
+  final List<TaskItem> removed = [];
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> setupChannels(BuildContext context) async {}
+
+  @override
+  Future<void> requestPermission() async {}
+
+  @override
+  Future<void> registerNotification(TaskItem task) async =>
+      registered.add(task);
+
+  @override
+  Future<void> removeNotification(TaskItem task) async => removed.add(task);
+}


### PR DESCRIPTION
## Summary

- `flutter_local_notifications` を使ってタスクの予定日当日 9:00 に通知をスケジュールする機能を追加
- `TaskNotificationSync` がタスク一覧のストリームを監視し、変化があった差分のみ通知を登録・解除する
- タイムゾーン対応のため `flutter_timezone` / `timezone` パッケージを追加

## Changes

**通知サービス**
- `NotificationService` インターフェース + `NotificationServiceImpl` を実装
  - `registerNotification(TaskItem)`: `scheduledAt` が未来の場合のみ `zonedSchedule` でスケジュール
  - `removeNotification(TaskItem)`: 通知をキャンセル
- Android / iOS の初期化・チャンネル設定・権限リクエストを追加

**通知同期**
- `TaskNotificationSync`: `allTaskItems()` ストリームを `distinct` + `pairwise` で監視し、Set の差分で追加・変更・削除を効率的に処理
- アプリ起動時に `main.dart` でタイムゾーン初期化 + sync サービスを起動

**テスト**
- `updateNotifications` を `@visibleForTesting` なトップレベル関数として分離
- `FakeNotificationService` を `test/helpers/` に追加
- タスク追加・削除・更新・変化なしの8ケースを同期テストでカバー

## Test plan

- [x] `fvm flutter test test/core/notification/task_notification_sync_test.dart` が全テスト通ること
- [ ] iOS / Android 実機でタスクを完了記録したとき、次回予定日の通知がスケジュールされること
- [ ] タスクを削除したとき、通知が解除されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)