### PR TITLE
設定のデバッグメニューに「登録済み通知をログ出力」ボタンを追加

### DIFF
--- a/lib/core/notification/notification_service.dart
+++ b/lib/core/notification/notification_service.dart
@@ -20,4 +20,6 @@ abstract interface class NotificationService {
   Future<void> syncExactAlarmPermission();
 
   Future<void> requestExactAlarmPermission();
+
+  Future<void> logPendingNotifications();
 }

--- a/lib/core/notification/notification_service_impl.dart
+++ b/lib/core/notification/notification_service_impl.dart
@@ -205,6 +205,17 @@ class NotificationServiceImpl implements NotificationService {
     await _plugin.cancelAll();
   }
 
+  @override
+  Future<void> logPendingNotifications() async {
+    if (!kDebugMode) return;
+    final pending = await _plugin.pendingNotificationRequests();
+    debugPrint('=== Pending Notifications (${pending.length}) ===');
+    for (final n in pending) {
+      debugPrint('  id=${n.id}, title="${n.title}", payload="${n.payload}"');
+    }
+    debugPrint('================================================');
+  }
+
   void _onNotificationResponse(NotificationResponse details) {
     // TODO: フォアグラウンドで通知を受け取ったときの処理を行う
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -208,6 +208,7 @@
   "settingsDebugAllTasksDeleted": "All tasks deleted",
   "settingsDebugResetTutorialFlag": "Reset tutorial flag",
   "settingsDebugTutorialFlagReset": "Tutorial flag reset",
+  "settingsDebugLogPendingNotifications": "Log pending notifications",
   "notificationGroupTask": "Task Notifications",
   "notificationChannelTask": "Individual Task Notification",
   "notificationTaskBody": "It's due today"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -208,6 +208,7 @@
   "settingsDebugAllTasksDeleted": "すべてのタスクを削除しました",
   "settingsDebugResetTutorialFlag": "チュートリアルフラグをリセット",
   "settingsDebugTutorialFlagReset": "チュートリアルフラグをリセットしました",
+  "settingsDebugLogPendingNotifications": "登録されている通知一覧をログ出力",
   "notificationGroupTask": "タスク通知",
   "notificationChannelTask": "個別タスク通知",
   "notificationTaskBody": "予定日になりました"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -830,6 +830,12 @@ abstract class AppLocalizations {
   /// **'チュートリアルフラグをリセットしました'**
   String get settingsDebugTutorialFlagReset;
 
+  /// No description provided for @settingsDebugLogPendingNotifications.
+  ///
+  /// In ja, this message translates to:
+  /// **'登録されている通知一覧をログ出力'**
+  String get settingsDebugLogPendingNotifications;
+
   /// No description provided for @notificationGroupTask.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -407,6 +407,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsDebugTutorialFlagReset => 'Tutorial flag reset';
 
   @override
+  String get settingsDebugLogPendingNotifications =>
+      'Log pending notifications';
+
+  @override
   String get notificationGroupTask => 'Task Notifications';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -401,6 +401,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsDebugTutorialFlagReset => 'チュートリアルフラグをリセットしました';
 
   @override
+  String get settingsDebugLogPendingNotifications => '登録されている通知一覧をログ出力';
+
+  @override
   String get notificationGroupTask => 'タスク通知';
 
   @override

--- a/lib/ui/settings/viewmodel/settings_view_model.dart
+++ b/lib/ui/settings/viewmodel/settings_view_model.dart
@@ -136,4 +136,9 @@ class SettingsViewModel extends _$SettingsViewModel {
     if (!ref.mounted) return;
     state = state.copyWith(snackBarMessage: TutorialFlagResetMessage());
   }
+
+  Future<void> logPendingNotifications() async {
+    final service = await ref.read(notificationServiceProvider.future);
+    await service.logPendingNotifications();
+  }
 }

--- a/lib/ui/settings/widget/settings_screen.dart
+++ b/lib/ui/settings/widget/settings_screen.dart
@@ -175,7 +175,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
       ),
       divider,
       AppListCell(
-        type: .bottom,
+        type: .middle,
         child: ListTile(
           contentPadding: const EdgeInsets.symmetric(horizontal: 16),
           title: Text(context.l10n.settingsDebugResetTutorialFlag),
@@ -186,6 +186,20 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
           ),
         ),
         onTap: () => viewModel.deleteTutorialFlag(),
+      ),
+      divider,
+      AppListCell(
+        type: .bottom,
+        child: ListTile(
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+          title: Text(context.l10n.settingsDebugLogPendingNotifications),
+          trailing: Icon(
+            Icons.arrow_forward_ios,
+            size: 16,
+            color: colorScheme.textMuted,
+          ),
+        ),
+        onTap: () => viewModel.logPendingNotifications(),
       ),
     ];
   }

--- a/test/helpers/fake_notification_service.dart
+++ b/test/helpers/fake_notification_service.dart
@@ -68,4 +68,7 @@ class FakeNotificationService implements NotificationService {
   Future<void> requestExactAlarmPermission() async {
     requestExactAlarmPermissionCalled = true;
   }
+
+  @override
+  Future<void> logPendingNotifications() async {}
 }


### PR DESCRIPTION
## 変更内容

- `NotificationService` に `logPendingNotifications()` を追加
- `NotificationServiceImpl` で `pendingNotificationRequests()` を使い `debugPrint` で出力（`kDebugMode` ガード付き）
- 設定画面のデバッグセクション末尾にボタンを追加（デバッグビルドのみ表示）
- `FakeNotificationService` に未実装メソッドを追加