### PR TITLE
通知の動作調査と設定テスト追加

### DIFF
--- a/lib/core/notification/notification_service_impl.dart
+++ b/lib/core/notification/notification_service_impl.dart
@@ -160,7 +160,11 @@ class NotificationServiceImpl implements NotificationService {
           _l10n.notificationChannelTask,
           importance: Importance.high,
         ),
-        iOS: const DarwinNotificationDetails(),
+        iOS: const DarwinNotificationDetails(
+          presentAlert: true,
+          presentBadge: true,
+          presentSound: true,
+        ),
       ),
       androidScheduleMode: await _resolveAndroidScheduleMode(),
       payload: task.id.toString(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,14 +5,18 @@ import 'package:dawnbreaker/core/notification/task_notification_sync_notifier.da
 import 'package:dawnbreaker/data/preferences/shared_preferences_provider.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initializeDateFormatting();
   tz.initializeTimeZones();
+  final localTimezone = await FlutterTimezone.getLocalTimezone();
+  tz.setLocalLocation(tz.getLocation(localTimezone.identifier));
 
   final preferences = await SharedPreferences.getInstance();
   final container = ProviderContainer(

--- a/test/ui/settings/viewmodel/settings_view_model_test.dart
+++ b/test/ui/settings/viewmodel/settings_view_model_test.dart
@@ -211,31 +211,55 @@ void main() {
           });
 
           group('exactAlarmの許可が必要な場合', () {
-            setUp(
-              () async => setUpLoaded(
-                notificationEnabled: false,
-                checkPermissionResult: false,
-                permissionResult: true,
-                canScheduleExactAlarmsResult: false,
-              ),
-            );
-
-            test('exactAlarm許可ダイアログが表示される', () async {
-              await viewModel.setNotificationEnabled(true);
-              expect(
-                viewState.dialogMessage,
-                isA<ExactAlarmPermissionRequestMessage>(),
+            group('通知権限を新規取得した場合', () {
+              setUp(
+                () async => setUpLoaded(
+                  notificationEnabled: false,
+                  checkPermissionResult: false,
+                  permissionResult: true,
+                  canScheduleExactAlarmsResult: false,
+                ),
               );
+
+              test('exactAlarm許可ダイアログが表示される', () async {
+                await viewModel.setNotificationEnabled(true);
+                expect(
+                  viewState.dialogMessage,
+                  isA<ExactAlarmPermissionRequestMessage>(),
+                );
+              });
+
+              test('ハンドラを呼び出すとアラームとリマインダー設定が開かれる', () async {
+                await viewModel.setNotificationEnabled(true);
+                viewState.dialogMessage!.primaryHandler!.call();
+                await pumpEventQueue();
+                expect(
+                  fakeNotificationService.requestExactAlarmPermissionCalled,
+                  true,
+                );
+              });
             });
 
-            test('ハンドラを呼び出すとアラームとリマインダー設定が開かれる', () async {
-              await viewModel.setNotificationEnabled(true);
-              viewState.dialogMessage!.primaryHandler!.call();
-              await pumpEventQueue();
-              expect(
-                fakeNotificationService.requestExactAlarmPermissionCalled,
-                true,
+            // exactAlarmはオプションのため、通知権限が既にある場合は再要求しない
+            // exactAlarm未許可のままでも通知は有効化し、不正確なタイマーで動作させる
+            group('通知権限が既にある場合', () {
+              setUp(
+                () async => setUpLoaded(
+                  notificationEnabled: false,
+                  checkPermissionResult: true,
+                  canScheduleExactAlarmsResult: false,
+                ),
               );
+
+              test('通知が有効になる', () async {
+                await viewModel.setNotificationEnabled(true);
+                expect(viewState.notificationEnabled, true);
+              });
+
+              test('exactAlarm許可ダイアログは表示されない', () async {
+                await viewModel.setNotificationEnabled(true);
+                expect(viewState.dialogMessage, isNull);
+              });
             });
           });
         });


### PR DESCRIPTION
## 変更内容

- タイムゾーンのズレを修正（`flutter_timezone` でローカルタイムゾーンを取得）
- iOS フォアグラウンド通知を有効化（`presentAlert/Badge/Sound: true`）
- 設定画面のテストに exact alarm 権限パターンを追加
  - 通知権限を新規取得した場合のみ exact alarm ダイアログを表示する設計を明示
  - 通知権限が既にある場合は exact alarm を再要求しない（optional 扱い）