### PR TITLE
AndroidスケジュールモードをalarmClockに変更

### DIFF
--- a/lib/core/notification/notification_service_impl.dart
+++ b/lib/core/notification/notification_service_impl.dart
@@ -20,11 +20,6 @@ Stream<bool> canScheduleExactAlarms(Ref ref) async* {
   yield* service.watchCanScheduleExactAlarms();
 }
 
-@pragma('vm:entry-point')
-void onDidReceiveBackgroundNotificationResponse(NotificationResponse details) {
-  // TODO: バックグラウンド・アプリキル状態で受け取った通知のハンドリングを行う
-}
-
 @Riverpod(keepAlive: true)
 Future<NotificationService> notificationService(Ref ref) async {
   final appLocalizations = await ref.watch(appLocalizationsProvider.future);
@@ -71,12 +66,7 @@ class NotificationServiceImpl implements NotificationService {
       android: _androidSettings,
       iOS: _iosSettings,
     );
-    await _plugin.initialize(
-      settings: settings,
-      onDidReceiveNotificationResponse: _onNotificationResponse,
-      onDidReceiveBackgroundNotificationResponse:
-          onDidReceiveBackgroundNotificationResponse,
-    );
+    await _plugin.initialize(settings: settings);
 
     if (Platform.isAndroid) {
       await _androidImplementation?.createNotificationChannelGroup(
@@ -173,7 +163,7 @@ class NotificationServiceImpl implements NotificationService {
 
   Future<AndroidScheduleMode> _resolveAndroidScheduleMode() async {
     final canExact = await canScheduleExactAlarms();
-    return canExact ? .exactAllowWhileIdle : .inexactAllowWhileIdle;
+    return canExact ? .alarmClock : .inexactAllowWhileIdle;
   }
 
   @override
@@ -218,9 +208,5 @@ class NotificationServiceImpl implements NotificationService {
       debugPrint('  id=${n.id}, title="${n.title}", payload="${n.payload}"');
     }
     debugPrint('================================================');
-  }
-
-  void _onNotificationResponse(NotificationResponse details) {
-    // TODO: フォアグラウンドで通知を受け取ったときの処理を行う
   }
 }


### PR DESCRIPTION
## 変更内容

- `AndroidScheduleMode` を `exactAllowWhileIdle` から `alarmClock` に変更
- 未実装の TODO コールバック (`onDidReceiveBackgroundNotificationResponse`, `_onNotificationResponse`) を削除

## 背景

- `setExactAndAllowWhileIdle()` は Deep Doze 中に throttle されるため、Pixel 9a + Android 16 環境で 9:00 にスケジュールした通知が夕方まで届かない問題が発生していた。
- `setAlarmClock()` を使う `alarmClock` モードで動作確認する