### PR TITLE
AppListCellのオーバースクロール時の描画崩れを修正

### DIFF
--- a/lib/ui/common/components/app_list_cell.dart
+++ b/lib/ui/common/components/app_list_cell.dart
@@ -60,16 +60,21 @@ class AppListCell extends StatelessWidget {
 
     return ConstrainedBox(
       constraints: const BoxConstraints(minHeight: 48),
-      child: Ink(
+      child: DecoratedBox(
         decoration: type.boxDecoration(
           backgroundColor: colors.surface,
           borderColor: colors.border,
           borderRadius: borderRadius,
         ),
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: borderRadius,
-          child: Align(alignment: Alignment.centerLeft, child: child),
+        child: ClipRRect(
+          borderRadius: borderRadius ?? BorderRadius.zero,
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: onTap,
+              child: Align(alignment: Alignment.centerLeft, child: child),
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## 概要

`AppListCell` で `Ink` を使っていたため、セルの背景・ボーダーが親 `Material`（Scaffold）のキャンバスに描画されていた。スクロール overshoot 時のバウンスアニメーションで `Divider` ウィジェット（通常キャンバス）とフレームがずれ、ディバイダーが二重に見える・背景が変な位置に見える現象が起きていた。

## スクショ

before | after
--- | ---
<img width="540" height="1212" alt="screenshot_20260524153004" src="https://github.com/user-attachments/assets/223185fe-3edf-4da3-b2fd-90709e07cc67" /> | <img width="540" height="1212" alt="screenshot_20260524153850" src="https://github.com/user-attachments/assets/633eb783-f36b-4f4a-a6d4-6b26fbffba8d" />


## 対応内容

- `Ink` → `DecoratedBox` に変更し、背景・ボーダーを通常キャンバスに描画して `Divider` と同一レイヤーに揃える
- `Material(color: transparent)` を `InkWell` 直上に挿入し、リップル効果をローカルな Material に描画させる
- `ClipRRect` で角丸クリッピングを担当（`InkWell.borderRadius` は不要になり除去）