### PR TITLE
設定画面にプログレスバーエフェクトの ON/OFF を追加

### DIFF
--- a/lib/core/util/stream_util.dart
+++ b/lib/core/util/stream_util.dart
@@ -1,5 +1,51 @@
 typedef CancelCallback = void Function();
 
+CancelCallback combineLatest4<T, S, U, V>(
+  Stream<T> stream1,
+  Stream<S> stream2,
+  Stream<U> stream3,
+  Stream<V> stream4,
+  void Function(T, S, U, V) combiner,
+) {
+  T? v1;
+  S? v2;
+  U? v3;
+  V? v4;
+
+  void tryEmit() {
+    final a = v1;
+    final b = v2;
+    final c = v3;
+    final d = v4;
+    if (a == null || b == null || c == null || d == null) return;
+    combiner(a, b, c, d);
+  }
+
+  final sub1 = stream1.listen((v) {
+    v1 = v;
+    tryEmit();
+  });
+  final sub2 = stream2.listen((v) {
+    v2 = v;
+    tryEmit();
+  });
+  final sub3 = stream3.listen((v) {
+    v3 = v;
+    tryEmit();
+  });
+  final sub4 = stream4.listen((v) {
+    v4 = v;
+    tryEmit();
+  });
+
+  return () {
+    sub1.cancel();
+    sub2.cancel();
+    sub3.cancel();
+    sub4.cancel();
+  };
+}
+
 CancelCallback combineLatest3<T, S, U>(
   Stream<T> stream1,
   Stream<S> stream2,

--- a/lib/data/preferences/preference_key.dart
+++ b/lib/data/preferences/preference_key.dart
@@ -8,3 +8,4 @@ const onboardingCompleteKey = PreferenceKey<bool>('onboarding_complete');
 const notificationEnabledKey = PreferenceKey<bool>('notification_enabled');
 const homeSortModeKey = PreferenceKey<String>('home_sort_mode');
 const colorSettingsKey = PreferenceKey<List<String>>('color_settings');
+const progressBarAnimationKey = PreferenceKey<bool>('progress_bar_animation');

--- a/lib/data/repository/settings/settings_repository.dart
+++ b/lib/data/repository/settings/settings_repository.dart
@@ -13,4 +13,8 @@ abstract interface class SettingsRepository {
   Stream<List<ColorSetting>> watchColorSettings();
 
   Future<void> setColorSettings(List<ColorSetting> settings);
+
+  Stream<bool> watchProgressBarAnimationEnabled();
+
+  Future<void> setProgressBarAnimationEnabled(bool value);
 }

--- a/lib/data/repository/settings/settings_repository_impl.dart
+++ b/lib/data/repository/settings/settings_repository_impl.dart
@@ -25,6 +25,10 @@ Stream<bool> notificationEnabled(Ref ref) =>
 Stream<HomeDisplayMode> homeDisplayMode(Ref ref) =>
     ref.watch(settingsRepositoryProvider).watchHomeDisplayMode();
 
+@Riverpod(keepAlive: true)
+Stream<bool> progressBarAnimationEnabled(Ref ref) =>
+    ref.watch(settingsRepositoryProvider).watchProgressBarAnimationEnabled();
+
 class SettingsRepositoryImpl implements SettingsRepository {
   SettingsRepositoryImpl(this._manager);
 
@@ -33,6 +37,7 @@ class SettingsRepositoryImpl implements SettingsRepository {
   final _homeSortModeController = StreamController<HomeDisplayMode>.broadcast();
   final _colorSettingsController =
       StreamController<List<ColorSetting>>.broadcast();
+  final _progressBarAnimationController = StreamController<bool>.broadcast();
 
   @override
   Stream<bool> watchNotificationEnabled() async* {
@@ -76,9 +81,22 @@ class SettingsRepositoryImpl implements SettingsRepository {
     _colorSettingsController.add(settings);
   }
 
+  @override
+  Stream<bool> watchProgressBarAnimationEnabled() async* {
+    yield _manager.get(progressBarAnimationKey, defaultValue: true);
+    yield* _progressBarAnimationController.stream;
+  }
+
+  @override
+  Future<void> setProgressBarAnimationEnabled(bool value) async {
+    await _manager.set(progressBarAnimationKey, value);
+    _progressBarAnimationController.add(value);
+  }
+
   void dispose() {
     _notificationEnabledController.close();
     _homeSortModeController.close();
     _colorSettingsController.close();
+    _progressBarAnimationController.close();
   }
 }

--- a/lib/data/repository/settings/settings_repository_impl.dart
+++ b/lib/data/repository/settings/settings_repository_impl.dart
@@ -21,14 +21,6 @@ SettingsRepository settingsRepository(Ref ref) {
 Stream<bool> notificationEnabled(Ref ref) =>
     ref.watch(settingsRepositoryProvider).watchNotificationEnabled();
 
-@Riverpod(keepAlive: true)
-Stream<HomeDisplayMode> homeDisplayMode(Ref ref) =>
-    ref.watch(settingsRepositoryProvider).watchHomeDisplayMode();
-
-@Riverpod(keepAlive: true)
-Stream<bool> progressBarAnimationEnabled(Ref ref) =>
-    ref.watch(settingsRepositoryProvider).watchProgressBarAnimationEnabled();
-
 class SettingsRepositoryImpl implements SettingsRepository {
   SettingsRepositoryImpl(this._manager);
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -209,6 +209,7 @@
   "settingsDisplayHomeTimelineSubtitle": "Shows tasks in chronological order, split into overdue and upcoming.",
   "settingsDisplayHomeByColor": "Color Groups",
   "settingsDisplayHomeByColorSubtitle": "Groups tasks by their assigned color.",
+  "settingsDisplayProgressBarAnimation": "Progress Bar Effects",
   "settingsColorGroupTitle": "Color Group Settings",
   "settingsColorGroupSubtitle": "Customize labels and order",
   "colorLabelScreenTitle": "Color Group Settings",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -209,6 +209,7 @@
   "settingsDisplayHomeTimelineSubtitle": "超過と今後の予定に分けて時系列で並べます",
   "settingsDisplayHomeByColor": "カラーグループ",
   "settingsDisplayHomeByColorSubtitle": "タスクの色でグループ分けします",
+  "settingsDisplayProgressBarAnimation": "プログレスバーエフェクト",
   "settingsColorGroupTitle": "カラーグループの設定",
   "settingsColorGroupSubtitle": "ラベルと並び順をカスタマイズ",
   "colorLabelScreenTitle": "カラーグループの設定",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -836,6 +836,12 @@ abstract class AppLocalizations {
   /// **'タスクの色でグループ分けします'**
   String get settingsDisplayHomeByColorSubtitle;
 
+  /// No description provided for @settingsDisplayProgressBarAnimation.
+  ///
+  /// In ja, this message translates to:
+  /// **'プログレスバーエフェクト'**
+  String get settingsDisplayProgressBarAnimation;
+
   /// No description provided for @settingsColorGroupTitle.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -412,6 +412,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Groups tasks by their assigned color.';
 
   @override
+  String get settingsDisplayProgressBarAnimation => 'Progress Bar Effects';
+
+  @override
   String get settingsColorGroupTitle => 'Color Group Settings';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -404,6 +404,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsDisplayHomeByColorSubtitle => 'タスクの色でグループ分けします';
 
   @override
+  String get settingsDisplayProgressBarAnimation => 'プログレスバーエフェクト';
+
+  @override
   String get settingsColorGroupTitle => 'カラーグループの設定';
 
   @override

--- a/lib/ui/common/components/app_progress_bar.dart
+++ b/lib/ui/common/components/app_progress_bar.dart
@@ -1,10 +1,12 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
+import 'package:dawnbreaker/data/repository/settings/settings_repository_impl.dart';
 import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class AppProgressBar extends StatelessWidget {
+class AppProgressBar extends ConsumerWidget {
   const AppProgressBar({
     super.key,
     required this.value,
@@ -32,12 +34,22 @@ class AppProgressBar extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final animated =
+        ref.watch(progressBarAnimationEnabledProvider).asData?.value ?? true;
     final c = context.appColorScheme;
     final (:base, :soft) = _barColors(c, value, isOverdue);
     final highlightColor = Color.lerp(base, soft, 0.6)!;
     final clamped = value.clamp(0.0, 1.0);
 
+    if (!animated) {
+      return _StaticBar(
+        clamped: clamped,
+        baseColor: base,
+        trackBg: c.trackBg,
+        thickness: thickness,
+      );
+    }
     if (value >= 1.0) {
       return _BlinkBar(
         clamped: clamped,

--- a/lib/ui/common/components/app_progress_bar.dart
+++ b/lib/ui/common/components/app_progress_bar.dart
@@ -1,17 +1,16 @@
 import 'package:dawnbreaker/app/app_colors.dart';
 import 'package:dawnbreaker/app/app_radius.dart';
-import 'package:dawnbreaker/data/repository/settings/settings_repository_impl.dart';
 import 'package:dawnbreaker/ui/common/components/preview_show_case.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widget_previews.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class AppProgressBar extends ConsumerWidget {
+class AppProgressBar extends StatelessWidget {
   const AppProgressBar({
     super.key,
     required this.value,
     this.isOverdue = false,
     this.thickness = 3,
+    this.animated = true,
   });
 
   /// 進捗 (0.0 〜 1.0)
@@ -21,6 +20,8 @@ class AppProgressBar extends ConsumerWidget {
 
   /// バーの太さ (dp)
   final double thickness;
+
+  final bool animated;
 
   static ({Color base, Color soft}) _barColors(
     AppColorScheme c,
@@ -34,9 +35,7 @@ class AppProgressBar extends ConsumerWidget {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final animated =
-        ref.watch(progressBarAnimationEnabledProvider).asData?.value ?? true;
+  Widget build(BuildContext context) {
     final c = context.appColorScheme;
     final (:base, :soft) = _barColors(c, value, isOverdue);
     final highlightColor = Color.lerp(base, soft, 0.6)!;

--- a/lib/ui/common/components/app_task_list_item.dart
+++ b/lib/ui/common/components/app_task_list_item.dart
@@ -15,11 +15,13 @@ class AppTaskListItem extends StatelessWidget {
     required this.task,
     this.onTap,
     this.onComplete,
+    this.progressBarAnimated = true,
   });
 
   final TaskItem task;
   final VoidCallback? onTap;
   final VoidCallback? onComplete;
+  final bool progressBarAnimated;
 
   @override
   Widget build(BuildContext context) {
@@ -80,6 +82,7 @@ class AppTaskListItem extends StatelessWidget {
                                   value: taskProgress.progress,
                                   isOverdue: taskProgress.isOverdue,
                                   thickness: 2,
+                                  animated: progressBarAnimated,
                                 ),
                               ],
                             ],

--- a/lib/ui/home/viewmodel/home_ui_state.dart
+++ b/lib/ui/home/viewmodel/home_ui_state.dart
@@ -25,6 +25,7 @@ abstract class HomeUiState with _$HomeUiState implements BaseUiState {
     @Default(HomeFilter.all) HomeFilter selectedFilter,
     @Default(HomeDisplayMode.timeline) HomeDisplayMode displayMode,
     @Default([]) List<ColorSetting> colorSettings,
+    @Default(true) bool progressBarAnimationEnabled,
   }) = _HomeUiState;
 
   bool get hasTasks => tasks.isNotEmpty;

--- a/lib/ui/home/viewmodel/home_ui_state.freezed.dart
+++ b/lib/ui/home/viewmodel/home_ui_state.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$HomeUiState {
 
- bool get isLoading; DialogMessage? get dialogMessage; SnackBarMessage? get snackBarMessage; List<TaskItem> get tasks; String get searchQuery; HomeFilter get selectedFilter; HomeDisplayMode get displayMode; List<ColorSetting> get colorSettings;
+ bool get isLoading; DialogMessage? get dialogMessage; SnackBarMessage? get snackBarMessage; List<TaskItem> get tasks; String get searchQuery; HomeFilter get selectedFilter; HomeDisplayMode get displayMode; List<ColorSetting> get colorSettings; bool get progressBarAnimationEnabled;
 /// Create a copy of HomeUiState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $HomeUiStateCopyWith<HomeUiState> get copyWith => _$HomeUiStateCopyWithImpl<Home
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is HomeUiState&&(identical(other.isLoading, isLoading) || other.isLoading == isLoading)&&(identical(other.dialogMessage, dialogMessage) || other.dialogMessage == dialogMessage)&&(identical(other.snackBarMessage, snackBarMessage) || other.snackBarMessage == snackBarMessage)&&const DeepCollectionEquality().equals(other.tasks, tasks)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&(identical(other.selectedFilter, selectedFilter) || other.selectedFilter == selectedFilter)&&(identical(other.displayMode, displayMode) || other.displayMode == displayMode)&&const DeepCollectionEquality().equals(other.colorSettings, colorSettings));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HomeUiState&&(identical(other.isLoading, isLoading) || other.isLoading == isLoading)&&(identical(other.dialogMessage, dialogMessage) || other.dialogMessage == dialogMessage)&&(identical(other.snackBarMessage, snackBarMessage) || other.snackBarMessage == snackBarMessage)&&const DeepCollectionEquality().equals(other.tasks, tasks)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&(identical(other.selectedFilter, selectedFilter) || other.selectedFilter == selectedFilter)&&(identical(other.displayMode, displayMode) || other.displayMode == displayMode)&&const DeepCollectionEquality().equals(other.colorSettings, colorSettings)&&(identical(other.progressBarAnimationEnabled, progressBarAnimationEnabled) || other.progressBarAnimationEnabled == progressBarAnimationEnabled));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,isLoading,dialogMessage,snackBarMessage,const DeepCollectionEquality().hash(tasks),searchQuery,selectedFilter,displayMode,const DeepCollectionEquality().hash(colorSettings));
+int get hashCode => Object.hash(runtimeType,isLoading,dialogMessage,snackBarMessage,const DeepCollectionEquality().hash(tasks),searchQuery,selectedFilter,displayMode,const DeepCollectionEquality().hash(colorSettings),progressBarAnimationEnabled);
 
 @override
 String toString() {
-  return 'HomeUiState(isLoading: $isLoading, dialogMessage: $dialogMessage, snackBarMessage: $snackBarMessage, tasks: $tasks, searchQuery: $searchQuery, selectedFilter: $selectedFilter, displayMode: $displayMode, colorSettings: $colorSettings)';
+  return 'HomeUiState(isLoading: $isLoading, dialogMessage: $dialogMessage, snackBarMessage: $snackBarMessage, tasks: $tasks, searchQuery: $searchQuery, selectedFilter: $selectedFilter, displayMode: $displayMode, colorSettings: $colorSettings, progressBarAnimationEnabled: $progressBarAnimationEnabled)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $HomeUiStateCopyWith<$Res>  {
   factory $HomeUiStateCopyWith(HomeUiState value, $Res Function(HomeUiState) _then) = _$HomeUiStateCopyWithImpl;
 @useResult
 $Res call({
- bool isLoading, DialogMessage? dialogMessage, SnackBarMessage? snackBarMessage, List<TaskItem> tasks, String searchQuery, HomeFilter selectedFilter, HomeDisplayMode displayMode, List<ColorSetting> colorSettings
+ bool isLoading, DialogMessage? dialogMessage, SnackBarMessage? snackBarMessage, List<TaskItem> tasks, String searchQuery, HomeFilter selectedFilter, HomeDisplayMode displayMode, List<ColorSetting> colorSettings, bool progressBarAnimationEnabled
 });
 
 
@@ -62,7 +62,7 @@ class _$HomeUiStateCopyWithImpl<$Res>
 
 /// Create a copy of HomeUiState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? isLoading = null,Object? dialogMessage = freezed,Object? snackBarMessage = freezed,Object? tasks = null,Object? searchQuery = null,Object? selectedFilter = null,Object? displayMode = null,Object? colorSettings = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? isLoading = null,Object? dialogMessage = freezed,Object? snackBarMessage = freezed,Object? tasks = null,Object? searchQuery = null,Object? selectedFilter = null,Object? displayMode = null,Object? colorSettings = null,Object? progressBarAnimationEnabled = null,}) {
   return _then(_self.copyWith(
 isLoading: null == isLoading ? _self.isLoading : isLoading // ignore: cast_nullable_to_non_nullable
 as bool,dialogMessage: freezed == dialogMessage ? _self.dialogMessage : dialogMessage // ignore: cast_nullable_to_non_nullable
@@ -72,7 +72,8 @@ as List<TaskItem>,searchQuery: null == searchQuery ? _self.searchQuery : searchQ
 as String,selectedFilter: null == selectedFilter ? _self.selectedFilter : selectedFilter // ignore: cast_nullable_to_non_nullable
 as HomeFilter,displayMode: null == displayMode ? _self.displayMode : displayMode // ignore: cast_nullable_to_non_nullable
 as HomeDisplayMode,colorSettings: null == colorSettings ? _self.colorSettings : colorSettings // ignore: cast_nullable_to_non_nullable
-as List<ColorSetting>,
+as List<ColorSetting>,progressBarAnimationEnabled: null == progressBarAnimationEnabled ? _self.progressBarAnimationEnabled : progressBarAnimationEnabled // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 
@@ -157,10 +158,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool isLoading,  DialogMessage? dialogMessage,  SnackBarMessage? snackBarMessage,  List<TaskItem> tasks,  String searchQuery,  HomeFilter selectedFilter,  HomeDisplayMode displayMode,  List<ColorSetting> colorSettings)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool isLoading,  DialogMessage? dialogMessage,  SnackBarMessage? snackBarMessage,  List<TaskItem> tasks,  String searchQuery,  HomeFilter selectedFilter,  HomeDisplayMode displayMode,  List<ColorSetting> colorSettings,  bool progressBarAnimationEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _HomeUiState() when $default != null:
-return $default(_that.isLoading,_that.dialogMessage,_that.snackBarMessage,_that.tasks,_that.searchQuery,_that.selectedFilter,_that.displayMode,_that.colorSettings);case _:
+return $default(_that.isLoading,_that.dialogMessage,_that.snackBarMessage,_that.tasks,_that.searchQuery,_that.selectedFilter,_that.displayMode,_that.colorSettings,_that.progressBarAnimationEnabled);case _:
   return orElse();
 
 }
@@ -178,10 +179,10 @@ return $default(_that.isLoading,_that.dialogMessage,_that.snackBarMessage,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool isLoading,  DialogMessage? dialogMessage,  SnackBarMessage? snackBarMessage,  List<TaskItem> tasks,  String searchQuery,  HomeFilter selectedFilter,  HomeDisplayMode displayMode,  List<ColorSetting> colorSettings)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool isLoading,  DialogMessage? dialogMessage,  SnackBarMessage? snackBarMessage,  List<TaskItem> tasks,  String searchQuery,  HomeFilter selectedFilter,  HomeDisplayMode displayMode,  List<ColorSetting> colorSettings,  bool progressBarAnimationEnabled)  $default,) {final _that = this;
 switch (_that) {
 case _HomeUiState():
-return $default(_that.isLoading,_that.dialogMessage,_that.snackBarMessage,_that.tasks,_that.searchQuery,_that.selectedFilter,_that.displayMode,_that.colorSettings);case _:
+return $default(_that.isLoading,_that.dialogMessage,_that.snackBarMessage,_that.tasks,_that.searchQuery,_that.selectedFilter,_that.displayMode,_that.colorSettings,_that.progressBarAnimationEnabled);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -198,10 +199,10 @@ return $default(_that.isLoading,_that.dialogMessage,_that.snackBarMessage,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool isLoading,  DialogMessage? dialogMessage,  SnackBarMessage? snackBarMessage,  List<TaskItem> tasks,  String searchQuery,  HomeFilter selectedFilter,  HomeDisplayMode displayMode,  List<ColorSetting> colorSettings)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool isLoading,  DialogMessage? dialogMessage,  SnackBarMessage? snackBarMessage,  List<TaskItem> tasks,  String searchQuery,  HomeFilter selectedFilter,  HomeDisplayMode displayMode,  List<ColorSetting> colorSettings,  bool progressBarAnimationEnabled)?  $default,) {final _that = this;
 switch (_that) {
 case _HomeUiState() when $default != null:
-return $default(_that.isLoading,_that.dialogMessage,_that.snackBarMessage,_that.tasks,_that.searchQuery,_that.selectedFilter,_that.displayMode,_that.colorSettings);case _:
+return $default(_that.isLoading,_that.dialogMessage,_that.snackBarMessage,_that.tasks,_that.searchQuery,_that.selectedFilter,_that.displayMode,_that.colorSettings,_that.progressBarAnimationEnabled);case _:
   return null;
 
 }
@@ -213,7 +214,7 @@ return $default(_that.isLoading,_that.dialogMessage,_that.snackBarMessage,_that.
 
 
 class _HomeUiState extends HomeUiState {
-  const _HomeUiState({this.isLoading = false, this.dialogMessage, this.snackBarMessage, final  List<TaskItem> tasks = const [], this.searchQuery = '', this.selectedFilter = HomeFilter.all, this.displayMode = HomeDisplayMode.timeline, final  List<ColorSetting> colorSettings = const []}): _tasks = tasks,_colorSettings = colorSettings,super._();
+  const _HomeUiState({this.isLoading = false, this.dialogMessage, this.snackBarMessage, final  List<TaskItem> tasks = const [], this.searchQuery = '', this.selectedFilter = HomeFilter.all, this.displayMode = HomeDisplayMode.timeline, final  List<ColorSetting> colorSettings = const [], this.progressBarAnimationEnabled = true}): _tasks = tasks,_colorSettings = colorSettings,super._();
   
 
 @override@JsonKey() final  bool isLoading;
@@ -236,6 +237,7 @@ class _HomeUiState extends HomeUiState {
   return EqualUnmodifiableListView(_colorSettings);
 }
 
+@override@JsonKey() final  bool progressBarAnimationEnabled;
 
 /// Create a copy of HomeUiState
 /// with the given fields replaced by the non-null parameter values.
@@ -247,16 +249,16 @@ _$HomeUiStateCopyWith<_HomeUiState> get copyWith => __$HomeUiStateCopyWithImpl<_
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HomeUiState&&(identical(other.isLoading, isLoading) || other.isLoading == isLoading)&&(identical(other.dialogMessage, dialogMessage) || other.dialogMessage == dialogMessage)&&(identical(other.snackBarMessage, snackBarMessage) || other.snackBarMessage == snackBarMessage)&&const DeepCollectionEquality().equals(other._tasks, _tasks)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&(identical(other.selectedFilter, selectedFilter) || other.selectedFilter == selectedFilter)&&(identical(other.displayMode, displayMode) || other.displayMode == displayMode)&&const DeepCollectionEquality().equals(other._colorSettings, _colorSettings));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HomeUiState&&(identical(other.isLoading, isLoading) || other.isLoading == isLoading)&&(identical(other.dialogMessage, dialogMessage) || other.dialogMessage == dialogMessage)&&(identical(other.snackBarMessage, snackBarMessage) || other.snackBarMessage == snackBarMessage)&&const DeepCollectionEquality().equals(other._tasks, _tasks)&&(identical(other.searchQuery, searchQuery) || other.searchQuery == searchQuery)&&(identical(other.selectedFilter, selectedFilter) || other.selectedFilter == selectedFilter)&&(identical(other.displayMode, displayMode) || other.displayMode == displayMode)&&const DeepCollectionEquality().equals(other._colorSettings, _colorSettings)&&(identical(other.progressBarAnimationEnabled, progressBarAnimationEnabled) || other.progressBarAnimationEnabled == progressBarAnimationEnabled));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,isLoading,dialogMessage,snackBarMessage,const DeepCollectionEquality().hash(_tasks),searchQuery,selectedFilter,displayMode,const DeepCollectionEquality().hash(_colorSettings));
+int get hashCode => Object.hash(runtimeType,isLoading,dialogMessage,snackBarMessage,const DeepCollectionEquality().hash(_tasks),searchQuery,selectedFilter,displayMode,const DeepCollectionEquality().hash(_colorSettings),progressBarAnimationEnabled);
 
 @override
 String toString() {
-  return 'HomeUiState(isLoading: $isLoading, dialogMessage: $dialogMessage, snackBarMessage: $snackBarMessage, tasks: $tasks, searchQuery: $searchQuery, selectedFilter: $selectedFilter, displayMode: $displayMode, colorSettings: $colorSettings)';
+  return 'HomeUiState(isLoading: $isLoading, dialogMessage: $dialogMessage, snackBarMessage: $snackBarMessage, tasks: $tasks, searchQuery: $searchQuery, selectedFilter: $selectedFilter, displayMode: $displayMode, colorSettings: $colorSettings, progressBarAnimationEnabled: $progressBarAnimationEnabled)';
 }
 
 
@@ -267,7 +269,7 @@ abstract mixin class _$HomeUiStateCopyWith<$Res> implements $HomeUiStateCopyWith
   factory _$HomeUiStateCopyWith(_HomeUiState value, $Res Function(_HomeUiState) _then) = __$HomeUiStateCopyWithImpl;
 @override @useResult
 $Res call({
- bool isLoading, DialogMessage? dialogMessage, SnackBarMessage? snackBarMessage, List<TaskItem> tasks, String searchQuery, HomeFilter selectedFilter, HomeDisplayMode displayMode, List<ColorSetting> colorSettings
+ bool isLoading, DialogMessage? dialogMessage, SnackBarMessage? snackBarMessage, List<TaskItem> tasks, String searchQuery, HomeFilter selectedFilter, HomeDisplayMode displayMode, List<ColorSetting> colorSettings, bool progressBarAnimationEnabled
 });
 
 
@@ -284,7 +286,7 @@ class __$HomeUiStateCopyWithImpl<$Res>
 
 /// Create a copy of HomeUiState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? isLoading = null,Object? dialogMessage = freezed,Object? snackBarMessage = freezed,Object? tasks = null,Object? searchQuery = null,Object? selectedFilter = null,Object? displayMode = null,Object? colorSettings = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? isLoading = null,Object? dialogMessage = freezed,Object? snackBarMessage = freezed,Object? tasks = null,Object? searchQuery = null,Object? selectedFilter = null,Object? displayMode = null,Object? colorSettings = null,Object? progressBarAnimationEnabled = null,}) {
   return _then(_HomeUiState(
 isLoading: null == isLoading ? _self.isLoading : isLoading // ignore: cast_nullable_to_non_nullable
 as bool,dialogMessage: freezed == dialogMessage ? _self.dialogMessage : dialogMessage // ignore: cast_nullable_to_non_nullable
@@ -294,7 +296,8 @@ as List<TaskItem>,searchQuery: null == searchQuery ? _self.searchQuery : searchQ
 as String,selectedFilter: null == selectedFilter ? _self.selectedFilter : selectedFilter // ignore: cast_nullable_to_non_nullable
 as HomeFilter,displayMode: null == displayMode ? _self.displayMode : displayMode // ignore: cast_nullable_to_non_nullable
 as HomeDisplayMode,colorSettings: null == colorSettings ? _self._colorSettings : colorSettings // ignore: cast_nullable_to_non_nullable
-as List<ColorSetting>,
+as List<ColorSetting>,progressBarAnimationEnabled: null == progressBarAnimationEnabled ? _self.progressBarAnimationEnabled : progressBarAnimationEnabled // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/lib/ui/home/viewmodel/home_view_model.dart
+++ b/lib/ui/home/viewmodel/home_view_model.dart
@@ -1,4 +1,4 @@
-import 'package:dawnbreaker/core/util/stream_util.dart';
+import 'package:dawnbreaker/core/util/stream_util.dart' show combineLatest4;
 import 'package:dawnbreaker/data/model/color_setting.dart';
 import 'package:dawnbreaker/data/model/home_display_mode.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
@@ -28,19 +28,22 @@ class HomeViewModel extends _$HomeViewModel {
   }
 
   void _initialize() {
-    final disposable = combineLatest3(
+    final disposable = combineLatest4(
       _taskRepository.allTaskItems(),
       _settingsRepository.watchHomeDisplayMode(),
       _settingsRepository.watchColorSettings(),
+      _settingsRepository.watchProgressBarAnimationEnabled(),
       (
         List<TaskItem> tasks,
         HomeDisplayMode mode,
         List<ColorSetting> colorSettings,
+        bool progressBarAnimationEnabled,
       ) => state = state.copyWith(
         isLoading: false,
         tasks: tasks,
         displayMode: mode,
         colorSettings: colorSettings,
+        progressBarAnimationEnabled: progressBarAnimationEnabled,
       ),
     );
     ref.onDispose(disposable);

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -97,6 +97,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
             uiState.hasTasks,
             taskList,
             viewModel,
+            uiState.progressBarAnimationEnabled,
           ),
           SliverPadding(
             padding: EdgeInsets.only(
@@ -113,6 +114,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     bool hasTasks,
     HomeTaskList taskList,
     HomeViewModel viewModel,
+    bool progressBarAnimationEnabled,
   ) {
     if (taskList.isEmpty) {
       final colors = context.appColorScheme;
@@ -142,6 +144,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           entry.value,
           viewModel,
           taskList,
+          progressBarAnimationEnabled: progressBarAnimationEnabled,
           addTopPadding: index > 0,
         ),
     ];
@@ -153,6 +156,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     List<TaskItem> tasks,
     HomeViewModel viewModel,
     HomeTaskList taskList, {
+    required bool progressBarAnimationEnabled,
     required bool addTopPadding,
   }) {
     final colors = context.appColorScheme;
@@ -188,6 +192,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                       onConfirm: (date, comment) =>
                           viewModel.recordExecution(item, date, comment),
                     ),
+                    progressBarAnimated: progressBarAnimationEnabled,
                   ),
                 ),
           ),

--- a/lib/ui/settings/viewmodel/settings_ui_state.dart
+++ b/lib/ui/settings/viewmodel/settings_ui_state.dart
@@ -14,6 +14,7 @@ abstract class SettingsUiState with _$SettingsUiState implements BaseUiState {
     @Default(true) bool notificationEnabled,
     @Default(false) bool isNotificationUpdating,
     @Default(HomeDisplayMode.timeline) HomeDisplayMode displayMode,
+    @Default(true) bool progressBarAnimationEnabled,
     DialogMessage? dialogMessage,
     SnackBarMessage? snackBarMessage,
   }) = _SettingsUiState;

--- a/lib/ui/settings/viewmodel/settings_view_model.dart
+++ b/lib/ui/settings/viewmodel/settings_view_model.dart
@@ -32,6 +32,12 @@ class SettingsViewModel extends _$SettingsViewModel {
     ref.listen(homeDisplayModeProvider, (_, next) {
       next.whenData((mode) => state = state.copyWith(displayMode: mode));
     });
+    ref.listen(progressBarAnimationEnabledProvider, (_, next) {
+      next.whenData(
+        (enabled) =>
+            state = state.copyWith(progressBarAnimationEnabled: enabled),
+      );
+    });
     _initialize();
     return const SettingsUiState();
   }
@@ -41,6 +47,7 @@ class SettingsViewModel extends _$SettingsViewModel {
       PackageInfo.fromPlatform(),
       _repository.watchNotificationEnabled().first,
       _repository.watchHomeDisplayMode().first,
+      _repository.watchProgressBarAnimationEnabled().first,
     ]);
     if (!ref.mounted) return;
     state = state.copyWith(
@@ -48,6 +55,7 @@ class SettingsViewModel extends _$SettingsViewModel {
       version: (results[0] as PackageInfo).version,
       notificationEnabled: results[1] as bool,
       displayMode: results[2] as HomeDisplayMode,
+      progressBarAnimationEnabled: results[3] as bool,
     );
   }
 
@@ -118,6 +126,10 @@ class SettingsViewModel extends _$SettingsViewModel {
     await ref.read(settingsRepositoryProvider).setNotificationEnabled(false);
     if (!ref.mounted) return;
     state = state.copyWith(isNotificationUpdating: false);
+  }
+
+  Future<void> setProgressBarAnimationEnabled(bool value) async {
+    await _repository.setProgressBarAnimationEnabled(value);
   }
 
   Future<void> generateDummyTasks() async {

--- a/lib/ui/settings/viewmodel/settings_view_model.dart
+++ b/lib/ui/settings/viewmodel/settings_view_model.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:app_settings/app_settings.dart';
 import 'package:dawnbreaker/core/notification/notification_service_impl.dart';
+import 'package:dawnbreaker/core/util/stream_util.dart' show combineLatest3;
 import 'package:dawnbreaker/data/model/color_setting.dart';
 import 'package:dawnbreaker/data/model/home_display_mode.dart';
 import 'package:dawnbreaker/data/repository/onboarding/onboarding_repository_impl.dart';
@@ -24,39 +25,28 @@ class SettingsViewModel extends _$SettingsViewModel {
   @override
   SettingsUiState build() {
     _repository = ref.read(settingsRepositoryProvider);
-    ref.listen(notificationEnabledProvider, (_, next) {
-      next.whenData(
-        (enabled) => state = state.copyWith(notificationEnabled: enabled),
-      );
-    });
-    ref.listen(homeDisplayModeProvider, (_, next) {
-      next.whenData((mode) => state = state.copyWith(displayMode: mode));
-    });
-    ref.listen(progressBarAnimationEnabledProvider, (_, next) {
-      next.whenData(
-        (enabled) =>
-            state = state.copyWith(progressBarAnimationEnabled: enabled),
-      );
-    });
     _initialize();
     return const SettingsUiState();
   }
 
   Future<void> _initialize() async {
-    final results = await Future.wait([
-      PackageInfo.fromPlatform(),
-      _repository.watchNotificationEnabled().first,
-      _repository.watchHomeDisplayMode().first,
-      _repository.watchProgressBarAnimationEnabled().first,
-    ]);
-    if (!ref.mounted) return;
-    state = state.copyWith(
-      isLoading: false,
-      version: (results[0] as PackageInfo).version,
-      notificationEnabled: results[1] as bool,
-      displayMode: results[2] as HomeDisplayMode,
-      progressBarAnimationEnabled: results[3] as bool,
+    final disposable = combineLatest3(
+      _repository.watchNotificationEnabled(),
+      _repository.watchHomeDisplayMode(),
+      _repository.watchProgressBarAnimationEnabled(),
+      (bool notification, HomeDisplayMode mode, bool animation) {
+        state = state.copyWith(
+          notificationEnabled: notification,
+          displayMode: mode,
+          progressBarAnimationEnabled: animation,
+        );
+      },
     );
+    ref.onDispose(disposable);
+
+    final info = await PackageInfo.fromPlatform();
+    if (!ref.mounted) return;
+    state = state.copyWith(isLoading: false, version: info.version);
   }
 
   Future<void> setNotificationEnabled(bool value) async {

--- a/lib/ui/settings/widget/settings_screen.dart
+++ b/lib/ui/settings/widget/settings_screen.dart
@@ -53,7 +53,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
               onNotificationChanged: _viewModel.setNotificationEnabled,
             ),
             const SizedBox(height: 24),
-            ..._displaySection(context, displayMode: viewState.displayMode),
+            ..._displaySection(
+              context,
+              displayMode: viewState.displayMode,
+              progressBarAnimationEnabled:
+                  viewState.progressBarAnimationEnabled,
+            ),
             const SizedBox(height: 24),
             ..._infoSection(context, viewState.version),
             if (kDebugMode) ...[
@@ -94,8 +99,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
   List<Widget> _displaySection(
     BuildContext context, {
     required HomeDisplayMode displayMode,
+    required bool progressBarAnimationEnabled,
   }) {
     final colorScheme = context.appColorScheme;
+    final divider = Divider(height: 1, color: colorScheme.divider);
     return [
       AppSectionHeader(
         title: Text(context.l10n.settingsSectionDisplay),
@@ -124,9 +131,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
         ),
         onTap: () => context.push('/settings/display'),
       ),
-      Divider(height: 1, color: colorScheme.divider),
+      divider,
       AppListCell(
-        type: .bottom,
+        type: .middle,
         child: ListTile(
           contentPadding: const EdgeInsets.symmetric(horizontal: 16),
           title: Text(context.l10n.settingsColorGroupTitle),
@@ -138,6 +145,17 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
           ),
         ),
         onTap: () => context.push('/settings/color-labels'),
+      ),
+      divider,
+      AppListCell(
+        type: .bottom,
+        child: ListTile(
+          title: Text(context.l10n.settingsDisplayProgressBarAnimation),
+          trailing: Switch(
+            value: progressBarAnimationEnabled,
+            onChanged: _viewModel.setProgressBarAnimationEnabled,
+          ),
+        ),
       ),
     ];
   }

--- a/lib/ui/settings/widget/settings_screen.dart
+++ b/lib/ui/settings/widget/settings_screen.dart
@@ -35,6 +35,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen>
     listenMessages(settingsViewModelProvider);
     final viewState = ref.watch(settingsViewModelProvider);
 
+    if (viewState.isLoading) {
+      return const Scaffold();
+    }
+
     final padding = MediaQuery.paddingOf(context);
     return Scaffold(
       appBar: AppAppBar(

--- a/test/data/repository/settings/settings_repository_test.dart
+++ b/test/data/repository/settings/settings_repository_test.dart
@@ -1,4 +1,5 @@
 import 'package:dawnbreaker/data/model/color_setting.dart';
+import 'package:dawnbreaker/data/model/home_display_mode.dart';
 import 'package:dawnbreaker/data/model/task_color.dart';
 import 'package:dawnbreaker/data/preferences/preference_key.dart';
 import 'package:dawnbreaker/data/repository/settings/settings_repository_impl.dart';
@@ -79,6 +80,71 @@ void main() {
     });
   });
 
+  group('watchHomeDisplayMode', () {
+    group('初期値が設定されていない場合', () {
+      setUp(() async {
+        manager = await FakePreferencesManager.create();
+        repository = SettingsRepositoryImpl(manager);
+      });
+
+      test('デフォルト値のtimelineが流れる', () async {
+        await expectLater(
+          repository.watchHomeDisplayMode().take(1),
+          emits(HomeDisplayMode.timeline),
+        );
+      });
+    });
+
+    group('初期値がbyColorの場合', () {
+      setUp(() async {
+        manager = await FakePreferencesManager.create(
+          mockValues: {homeSortModeKey.rawKey: 'by_color'},
+        );
+        repository = SettingsRepositoryImpl(manager);
+      });
+
+      test('byColorが流れる', () async {
+        await expectLater(
+          repository.watchHomeDisplayMode().take(1),
+          emits(HomeDisplayMode.byColor),
+        );
+      });
+    });
+  });
+
+  group('setHomeDisplayMode', () {
+    setUp(() async {
+      manager = await FakePreferencesManager.create();
+      repository = SettingsRepositoryImpl(manager);
+    });
+
+    test('変更した値がstreamに流れる', () async {
+      final expectation = expectLater(
+        repository.watchHomeDisplayMode().take(2),
+        emitsInOrder([HomeDisplayMode.timeline, HomeDisplayMode.byColor]),
+      );
+      await pumpEventQueue();
+
+      await repository.setHomeDisplayMode(.byColor);
+      await expectation;
+    });
+
+    test('変更した値がストレージに保存される', () async {
+      await repository.setHomeDisplayMode(.byColor);
+
+      expect(manager.get(homeSortModeKey, defaultValue: ''), 'by_color');
+    });
+
+    test('変更後の新しいsubscriberは最新値を受け取る', () async {
+      await repository.setHomeDisplayMode(.byColor);
+
+      await expectLater(
+        repository.watchHomeDisplayMode().take(1),
+        emits(HomeDisplayMode.byColor),
+      );
+    });
+  });
+
   group('watchColorSettings', () {
     group('初期値が設定されていない場合', () {
       setUp(() async {
@@ -149,6 +215,71 @@ void main() {
       expect(manager.get(colorSettingsKey, defaultValue: const <String>[]), [
         'green:0:植物',
       ]);
+    });
+  });
+
+  group('watchProgressBarAnimationEnabled', () {
+    group('初期値が設定されていない場合', () {
+      setUp(() async {
+        manager = await FakePreferencesManager.create();
+        repository = SettingsRepositoryImpl(manager);
+      });
+
+      test('デフォルト値のtrueが流れる', () async {
+        await expectLater(
+          repository.watchProgressBarAnimationEnabled().take(1),
+          emits(true),
+        );
+      });
+    });
+
+    group('初期値がfalseの場合', () {
+      setUp(() async {
+        manager = await FakePreferencesManager.create(
+          mockValues: {progressBarAnimationKey.rawKey: false},
+        );
+        repository = SettingsRepositoryImpl(manager);
+      });
+
+      test('falseが流れる', () async {
+        await expectLater(
+          repository.watchProgressBarAnimationEnabled().take(1),
+          emits(false),
+        );
+      });
+    });
+  });
+
+  group('setProgressBarAnimationEnabled', () {
+    setUp(() async {
+      manager = await FakePreferencesManager.create();
+      repository = SettingsRepositoryImpl(manager);
+    });
+
+    test('変更した値がstreamに流れる', () async {
+      final expectation = expectLater(
+        repository.watchProgressBarAnimationEnabled().take(2),
+        emitsInOrder([true, false]),
+      );
+      await pumpEventQueue();
+
+      await repository.setProgressBarAnimationEnabled(false);
+      await expectation;
+    });
+
+    test('変更した値がストレージに保存される', () async {
+      await repository.setProgressBarAnimationEnabled(false);
+
+      expect(manager.get(progressBarAnimationKey, defaultValue: true), false);
+    });
+
+    test('変更後の新しいsubscriberは最新値を受け取る', () async {
+      await repository.setProgressBarAnimationEnabled(false);
+
+      await expectLater(
+        repository.watchProgressBarAnimationEnabled().take(1),
+        emits(false),
+      );
     });
   });
 }

--- a/test/helpers/fake_settings_repository.dart
+++ b/test/helpers/fake_settings_repository.dart
@@ -9,17 +9,21 @@ class FakeSettingsRepository implements SettingsRepository {
     bool initialNotificationEnabled = true,
     HomeDisplayMode initialDisplayMode = HomeDisplayMode.timeline,
     List<ColorSetting>? initialColorSettings,
+    bool initialProgressBarAnimationEnabled = true,
   }) : notificationEnabled = initialNotificationEnabled,
        displayMode = initialDisplayMode,
-       colorSettings = initialColorSettings ?? ColorSetting.defaults();
+       colorSettings = initialColorSettings ?? ColorSetting.defaults(),
+       progressBarAnimationEnabled = initialProgressBarAnimationEnabled;
 
   bool notificationEnabled;
   HomeDisplayMode displayMode;
   List<ColorSetting> colorSettings;
+  bool progressBarAnimationEnabled;
   final _notificationController = StreamController<bool>.broadcast();
   final _displayModeController = StreamController<HomeDisplayMode>.broadcast();
   final _colorSettingsController =
       StreamController<List<ColorSetting>>.broadcast();
+  final _progressBarAnimationController = StreamController<bool>.broadcast();
 
   @override
   Stream<bool> watchNotificationEnabled() async* {
@@ -55,5 +59,17 @@ class FakeSettingsRepository implements SettingsRepository {
   Future<void> setColorSettings(List<ColorSetting> settings) async {
     colorSettings = settings;
     _colorSettingsController.add(settings);
+  }
+
+  @override
+  Stream<bool> watchProgressBarAnimationEnabled() async* {
+    yield progressBarAnimationEnabled;
+    yield* _progressBarAnimationController.stream;
+  }
+
+  @override
+  Future<void> setProgressBarAnimationEnabled(bool value) async {
+    progressBarAnimationEnabled = value;
+    _progressBarAnimationController.add(value);
   }
 }

--- a/test/ui/settings/viewmodel/settings_view_model_test.dart
+++ b/test/ui/settings/viewmodel/settings_view_model_test.dart
@@ -34,6 +34,7 @@ void main() {
     bool permissionResult = true,
     bool canScheduleExactAlarmsResult = true,
     HomeDisplayMode initialDisplayMode = HomeDisplayMode.timeline,
+    bool initialProgressBarAnimationEnabled = true,
   }) {
     PackageInfo.setMockInitialValues(
       appName: 'dawnbreaker',
@@ -46,6 +47,7 @@ void main() {
     fakeSettingsRepository = FakeSettingsRepository(
       initialNotificationEnabled: notificationEnabled,
       initialDisplayMode: initialDisplayMode,
+      initialProgressBarAnimationEnabled: initialProgressBarAnimationEnabled,
     );
     fakeNotificationService = FakeNotificationService(
       checkPermissionResult: checkPermissionResult,
@@ -71,6 +73,7 @@ void main() {
     bool permissionResult = true,
     bool canScheduleExactAlarmsResult = true,
     HomeDisplayMode initialDisplayMode = HomeDisplayMode.timeline,
+    bool initialProgressBarAnimationEnabled = true,
   }) async {
     setUpContainer(
       notificationEnabled: notificationEnabled,
@@ -78,6 +81,7 @@ void main() {
       permissionResult: permissionResult,
       canScheduleExactAlarmsResult: canScheduleExactAlarmsResult,
       initialDisplayMode: initialDisplayMode,
+      initialProgressBarAnimationEnabled: initialProgressBarAnimationEnabled,
     );
     await waitUntil(container, settingsViewModelProvider, (s) => !s.isLoading);
     viewModel = container.read(settingsViewModelProvider.notifier);
@@ -324,6 +328,40 @@ void main() {
         test('完了メッセージが表示される', () async {
           await viewModel.deleteTutorialFlag();
           expect(viewState.snackBarMessage, isA<TutorialFlagResetMessage>());
+        });
+      });
+
+      group('プログレスバーアニメーションの初期値', () {
+        for (final (enabled, label) in [(true, '有効'), (false, '無効')]) {
+          test('$labelが正しく読み込まれる', () async {
+            await setUpLoaded(initialProgressBarAnimationEnabled: enabled);
+            expect(viewState.progressBarAnimationEnabled, enabled);
+          });
+        }
+      });
+
+      group('setProgressBarAnimationEnabled', () {
+        setUp(() async => setUpLoaded());
+
+        test('アニメーションが無効になる', () async {
+          await viewModel.setProgressBarAnimationEnabled(false);
+          await pumpEventQueue();
+          expect(viewState.progressBarAnimationEnabled, false);
+        });
+
+        test('リポジトリに保存される', () async {
+          await viewModel.setProgressBarAnimationEnabled(false);
+          expect(fakeSettingsRepository.progressBarAnimationEnabled, false);
+        });
+      });
+
+      group('プログレスバーアニメーションの外部変更', () {
+        setUp(() async => setUpLoaded());
+
+        test('リポジトリの変更がstateに反映される', () async {
+          await fakeSettingsRepository.setProgressBarAnimationEnabled(false);
+          await pumpEventQueue();
+          expect(viewState.progressBarAnimationEnabled, false);
         });
       });
     });


### PR DESCRIPTION
## 変更内容

- プログレスバーのグリマー・ブリンクエフェクトをオフにできる設定を追加
- 設定項目の順序を変更（表示タイプ → カラーグループ設定 → プログレスバーエフェクト）
- ロード完了前は空の `Scaffold` を返すことでスイッチが一瞬点滅する問題を修正