### PR TITLE
Update Firebase Flutter packages to v4/v5/v12

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,10 +35,10 @@ dependencies:
   timezone: ^0.11.0
   app_settings: ^7.0.0
   flutter_native_splash: ^2.4.5
-  firebase_core: ^3.6.0
-  firebase_crashlytics: ^4.3.10
+  firebase_core: ^4.0.0
+  firebase_crashlytics: ^5.0.0
   logger: ^2.5.0
-  firebase_analytics: ^11.6.0
+  firebase_analytics: ^12.0.0
 
 dev_dependencies:
   flutter_test:

--- a/renovate.json5
+++ b/renovate.json5
@@ -17,6 +17,16 @@
     {
       "matchPackageNames": ["dev.flutter.flutter-plugin-loader.gradle.plugin"],
       "enabled": false
+    },
+    {
+      "matchPackagePrefixes": ["firebase_"],
+      "matchManagers": ["pub"],
+      "groupName": "Firebase Flutter packages"
+    },
+    {
+      "matchPackagePrefixes": ["com.google.firebase", "com.google.gms"],
+      "matchManagers": ["gradle"],
+      "groupName": "Firebase Gradle plugins"
     }
   ],
 }


### PR DESCRIPTION
Renovate が個別に出した Firebase 関連 PR (#120, #122, #123) は依存関係の競合で `pubspec.lock` が更新できない状態だったため、一括で更新する。

## 変更内容

### pubspec.yaml
- `firebase_core`: `^3.6.0` → `^4.0.0`
- `firebase_crashlytics`: `^4.3.10` → `^5.0.0`
- `firebase_analytics`: `^11.6.0` → `^12.0.0`

### renovate.json5
- Firebase Flutter パッケージをグループ化（次回から1つの PR にまとまるように）
- Firebase Gradle プラグインをグループ化

## 注意
マージ前にローカルで `fvm flutter pub get` を実行して `pubspec.lock` を更新してコミットに含めること。

---
_Generated by [Claude Code](https://claude.ai/code/session_01SN2qUPrLDBscba78zadJbd)_