### PR TITLE
Firebase移行 Phase1: IDをintからStringに変更

### DIFF
--- a/lib/app/app_router.dart
+++ b/lib/app/app_router.dart
@@ -37,13 +37,12 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: '/app-detail/:taskId',
         builder: (_, state) =>
-            AppDetailScreen(taskId: int.parse(state.pathParameters['taskId']!)),
+            AppDetailScreen(taskId: state.pathParameters['taskId']!),
         routes: [
           GoRoute(
             path: 'edit',
-            builder: (_, state) => EditorScreen(
-              taskId: int.parse(state.pathParameters['taskId']!),
-            ),
+            builder: (_, state) =>
+                EditorScreen(taskId: state.pathParameters['taskId']!),
           ),
         ],
       ),

--- a/lib/core/notification/notification_service_impl.dart
+++ b/lib/core/notification/notification_service_impl.dart
@@ -143,9 +143,9 @@ class NotificationServiceImpl implements NotificationService {
       return;
     }
 
-    await _plugin.cancel(id: task.id);
+    await _plugin.cancel(id: _notificationId(task.id));
     await _plugin.zonedSchedule(
-      id: task.id,
+      id: _notificationId(task.id),
       title: task.name,
       body: _l10n.notificationTaskBody,
       scheduledDate: notifyAt,
@@ -162,7 +162,7 @@ class NotificationServiceImpl implements NotificationService {
         ),
       ),
       androidScheduleMode: await _resolveAndroidScheduleMode(),
-      payload: task.id.toString(),
+      payload: task.id,
     );
   }
 
@@ -196,7 +196,7 @@ class NotificationServiceImpl implements NotificationService {
 
   @override
   Future<void> removeNotification(TaskItem task) async {
-    await _plugin.cancel(id: task.id);
+    await _plugin.cancel(id: _notificationId(task.id));
   }
 
   @override
@@ -214,4 +214,8 @@ class NotificationServiceImpl implements NotificationService {
     }
     debugPrint('================================================');
   }
+
+  // Dart の int は 64bit なのでそのまま Android に渡すと問題が生じるため、
+  // 32bitの正の数にマスクする
+  int _notificationId(String taskId) => taskId.hashCode & 0x7FFFFFFF;
 }

--- a/lib/data/database/tables/task_definitions_table.dart
+++ b/lib/data/database/tables/task_definitions_table.dart
@@ -3,7 +3,7 @@ import 'package:dawnbreaker/data/model/task_type.dart';
 import 'package:drift/drift.dart';
 
 class TaskDefinitions extends Table {
-  IntColumn get id => integer().autoIncrement()();
+  TextColumn get id => text()();
 
   TextColumn get taskType =>
       text().map(const EnumNameConverter(TaskType.values))();
@@ -16,4 +16,7 @@ class TaskDefinitions extends Table {
 
   TextColumn get color =>
       text().map(const EnumNameConverter(TaskColor.values))();
+
+  @override
+  Set<Column> get primaryKey => {id};
 }

--- a/lib/data/database/tables/task_executions_table.dart
+++ b/lib/data/database/tables/task_executions_table.dart
@@ -6,12 +6,15 @@ import 'package:drift/drift.dart';
   columns: {#taskDefinitionId, #executedAt},
 )
 class TaskExecutions extends Table {
-  IntColumn get id => integer().autoIncrement()();
+  TextColumn get id => text()();
 
-  IntColumn get taskDefinitionId =>
-      integer().references(TaskDefinitions, #id, onDelete: KeyAction.cascade)();
+  TextColumn get taskDefinitionId =>
+      text().references(TaskDefinitions, #id, onDelete: KeyAction.cascade)();
 
   DateTimeColumn get executedAt => dateTime()();
 
   TextColumn get comment => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
 }

--- a/lib/data/database/tables/task_scheduled_configs_table.dart
+++ b/lib/data/database/tables/task_scheduled_configs_table.dart
@@ -5,8 +5,8 @@ import 'package:dawnbreaker/data/model/schedule_unit.dart';
 import 'package:drift/drift.dart';
 
 class TaskScheduledConfigs extends Table {
-  IntColumn get taskDefinitionId =>
-      integer().references(TaskDefinitions, #id, onDelete: KeyAction.cascade)();
+  TextColumn get taskDefinitionId =>
+      text().references(TaskDefinitions, #id, onDelete: KeyAction.cascade)();
 
   IntColumn get scheduleValue => integer()();
 

--- a/lib/data/model/task_history.dart
+++ b/lib/data/model/task_history.dart
@@ -5,7 +5,7 @@ part 'task_history.freezed.dart';
 @freezed
 abstract class TaskHistory with _$TaskHistory {
   const factory TaskHistory({
-    required int id,
+    required String id,
     required DateTime executedAt,
     required String? comment,
   }) = _TaskHistory;

--- a/lib/data/model/task_item.dart
+++ b/lib/data/model/task_item.dart
@@ -12,7 +12,7 @@ sealed class TaskItem with _$TaskItem {
   const TaskItem._();
 
   const factory TaskItem.irregular({
-    required int id,
+    required String id,
     required String name,
     required String furigana,
     required String icon,
@@ -21,7 +21,7 @@ sealed class TaskItem with _$TaskItem {
   }) = IrregularTaskItem;
 
   const factory TaskItem.period({
-    required int id,
+    required String id,
     required String name,
     required String furigana,
     required String icon,
@@ -30,7 +30,7 @@ sealed class TaskItem with _$TaskItem {
   }) = PeriodTaskItem;
 
   const factory TaskItem.scheduled({
-    required int id,
+    required String id,
     required String name,
     required String furigana,
     required String icon,

--- a/lib/data/repository/task/task_repository.dart
+++ b/lib/data/repository/task/task_repository.dart
@@ -7,11 +7,11 @@ import 'package:dawnbreaker/data/model/task_type.dart';
 abstract interface class TaskRepository {
   Stream<List<TaskItem>> allTaskItems();
 
-  Stream<TaskItem?> watchTaskById(int taskId);
+  Stream<TaskItem?> watchTaskById(String taskId);
 
-  Future<TaskItem> findTaskById(int taskId);
+  Future<TaskItem> findTaskById(String taskId);
 
-  Future<int> addTask({
+  Future<String> addTask({
     required TaskType taskType,
     required String name,
     required String icon,
@@ -21,7 +21,7 @@ abstract interface class TaskRepository {
   });
 
   Future<void> updateTask({
-    required int taskId,
+    required String taskId,
     required TaskType taskType,
     required String name,
     required String icon,
@@ -31,20 +31,20 @@ abstract interface class TaskRepository {
   });
 
   Future<TaskHistory> recordExecution(
-    int taskId, {
+    String taskId, {
     required DateTime executedAt,
     String? comment,
   });
 
   Future<void> updateExecution(
-    int executionId, {
+    String executionId, {
     required DateTime executedAt,
     String? comment,
   });
 
-  Future<void> deleteExecution(int executionId);
+  Future<void> deleteExecution(String executionId);
 
-  Future<void> deleteTask(int taskId);
+  Future<void> deleteTask(String taskId);
 
   Future<void> deleteAllTasks();
 

--- a/lib/data/repository/task/task_repository_exception.dart
+++ b/lib/data/repository/task/task_repository_exception.dart
@@ -9,7 +9,7 @@ sealed class TaskRepositoryException implements Exception {
 
 class TaskNotFoundException extends TaskRepositoryException {
   const TaskNotFoundException({required this.taskId}) : super();
-  final int taskId;
+  final String taskId;
 }
 
 class TaskLoadException extends TaskRepositoryException {

--- a/lib/data/repository/task/task_repository_impl.dart
+++ b/lib/data/repository/task/task_repository_impl.dart
@@ -11,8 +11,11 @@ import 'package:dawnbreaker/data/repository/task/task_repository.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository_exception.dart';
 import 'package:drift/drift.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:uuid/uuid.dart';
 
 part 'task_repository_impl.g.dart';
+
+const _uuid = Uuid();
 
 @riverpod
 TaskRepository taskRepository(Ref ref) {
@@ -34,7 +37,7 @@ class TaskRepositoryImpl implements TaskRepository {
   }
 
   @override
-  Stream<TaskItem?> watchTaskById(int taskId) {
+  Stream<TaskItem?> watchTaskById(String taskId) {
     return _baseTaskQuery(
       where: _db.taskDefinitions.id.equals(taskId),
     ).watch().map((rows) {
@@ -44,7 +47,7 @@ class TaskRepositoryImpl implements TaskRepository {
   }
 
   @override
-  Future<TaskItem> findTaskById(int taskId) async {
+  Future<TaskItem> findTaskById(String taskId) async {
     try {
       final rows = await _baseTaskQuery(
         where: _db.taskDefinitions.id.equals(taskId),
@@ -148,7 +151,7 @@ class TaskRepositoryImpl implements TaskRepository {
   }
 
   @override
-  Future<int> addTask({
+  Future<String> addTask({
     required TaskType taskType,
     required String name,
     required String icon,
@@ -164,11 +167,13 @@ class TaskRepositoryImpl implements TaskRepository {
     }
     try {
       final furigana = await _furiganaTranslate.translate(name);
-      return await _db.transaction(() async {
-        final id = await _db
+      final id = _uuid.v4();
+      await _db.transaction(() async {
+        await _db
             .into(_db.taskDefinitions)
             .insert(
               TaskDefinitionsCompanion.insert(
+                id: id,
                 taskType: taskType,
                 name: name,
                 furigana: furigana,
@@ -181,14 +186,14 @@ class TaskRepositoryImpl implements TaskRepository {
               .into(_db.taskScheduledConfigs)
               .insert(
                 TaskScheduledConfigsCompanion.insert(
-                  taskDefinitionId: Value(id),
+                  taskDefinitionId: id,
                   scheduleValue: scheduleValue!,
                   scheduleUnit: scheduleUnit!,
                 ),
               );
         }
-        return id;
       });
+      return id;
     } catch (e) {
       throw TaskSaveException(e.toString());
     }
@@ -196,15 +201,17 @@ class TaskRepositoryImpl implements TaskRepository {
 
   @override
   Future<TaskHistory> recordExecution(
-    int taskId, {
+    String taskId, {
     required DateTime executedAt,
     String? comment,
   }) async {
     try {
-      final id = await _db
+      final id = _uuid.v4();
+      await _db
           .into(_db.taskExecutions)
           .insert(
             TaskExecutionsCompanion.insert(
+              id: id,
               taskDefinitionId: taskId,
               executedAt: executedAt,
               comment: Value(comment),
@@ -218,7 +225,7 @@ class TaskRepositoryImpl implements TaskRepository {
 
   @override
   Future<void> updateExecution(
-    int executionId, {
+    String executionId, {
     required DateTime executedAt,
     String? comment,
   }) async {
@@ -237,7 +244,7 @@ class TaskRepositoryImpl implements TaskRepository {
   }
 
   @override
-  Future<void> deleteExecution(int executionId) async {
+  Future<void> deleteExecution(String executionId) async {
     try {
       await (_db.delete(
         _db.taskExecutions,
@@ -249,7 +256,7 @@ class TaskRepositoryImpl implements TaskRepository {
 
   @override
   Future<void> updateTask({
-    required int taskId,
+    required String taskId,
     required TaskType taskType,
     required String name,
     required String icon,
@@ -287,7 +294,7 @@ class TaskRepositoryImpl implements TaskRepository {
                 .into(_db.taskScheduledConfigs)
                 .insertOnConflictUpdate(
                   TaskScheduledConfigsCompanion.insert(
-                    taskDefinitionId: Value(taskId),
+                    taskDefinitionId: taskId,
                     scheduleValue: scheduleValue,
                     scheduleUnit: scheduleUnit,
                   ),
@@ -302,7 +309,7 @@ class TaskRepositoryImpl implements TaskRepository {
   }
 
   @override
-  Future<void> deleteTask(int taskId) async {
+  Future<void> deleteTask(String taskId) async {
     try {
       await (_db.delete(
         _db.taskDefinitions,
@@ -325,11 +332,13 @@ class TaskRepositoryImpl implements TaskRepository {
   @override
   Future<void> restoreTask(TaskItem taskItem) async {
     try {
+      final newId = _uuid.v4();
       await _db.transaction(() async {
-        final id = await _db
+        await _db
             .into(_db.taskDefinitions)
             .insert(
               TaskDefinitionsCompanion.insert(
+                id: newId,
                 taskType: taskItem.taskType,
                 name: taskItem.name,
                 furigana: taskItem.furigana,
@@ -342,7 +351,7 @@ class TaskRepositoryImpl implements TaskRepository {
               .into(_db.taskScheduledConfigs)
               .insert(
                 TaskScheduledConfigsCompanion.insert(
-                  taskDefinitionId: Value(id),
+                  taskDefinitionId: newId,
                   scheduleValue: taskItem.scheduleValueOrDefault,
                   scheduleUnit: taskItem.scheduleUnitOrDefault,
                 ),
@@ -353,7 +362,8 @@ class TaskRepositoryImpl implements TaskRepository {
             _db.taskExecutions,
             taskItem.taskHistory.map(
               (history) => TaskExecutionsCompanion.insert(
-                taskDefinitionId: id,
+                id: _uuid.v4(),
+                taskDefinitionId: newId,
                 executedAt: history.executedAt,
                 comment: Value(history.comment),
               ),

--- a/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
+++ b/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
@@ -17,13 +17,13 @@ class AppDetailViewModel extends _$AppDetailViewModel {
   late TaskRepository _repository;
 
   @override
-  AppDetailUiState build({required int taskId}) {
+  AppDetailUiState build({required String taskId}) {
     _repository = ref.read(taskRepositoryProvider);
     _loadTask(taskId);
     return const AppDetailUiState();
   }
 
-  void _loadTask(int taskId) {
+  void _loadTask(String taskId) {
     final subscription = _repository
         .watchTaskById(taskId)
         .listen(

--- a/lib/ui/app_detail/widgets/app_detail_screen.dart
+++ b/lib/ui/app_detail/widgets/app_detail_screen.dart
@@ -26,7 +26,7 @@ import 'package:go_router/go_router.dart';
 class AppDetailScreen extends ConsumerStatefulWidget {
   const AppDetailScreen({super.key, required this.taskId});
 
-  final int taskId;
+  final String taskId;
 
   @override
   ConsumerState<AppDetailScreen> createState() => _AppDetailScreenState();

--- a/lib/ui/color_label/viewmodel/color_label_view_model.g.dart
+++ b/lib/ui/color_label/viewmodel/color_label_view_model.g.dart
@@ -42,7 +42,7 @@ final class ColorLabelViewModelProvider
 }
 
 String _$colorLabelViewModelHash() =>
-    r'7046a1a0c0c3118d5d2bc98564ebfd67fb7f56df';
+    r'a43797b3626190f3598c522c13f941f11d22029d';
 
 abstract class _$ColorLabelViewModel extends $Notifier<ColorLabelUiState> {
   ColorLabelUiState build();

--- a/lib/ui/editor/viewmodel/editor_view_model.dart
+++ b/lib/ui/editor/viewmodel/editor_view_model.dart
@@ -20,7 +20,7 @@ class EditorViewModel extends _$EditorViewModel {
   late TaskRepository _repository;
 
   @override
-  EditorUiState build({int? taskId}) {
+  EditorUiState build({String? taskId}) {
     _repository = ref.read(taskRepositoryProvider);
     if (taskId != null) {
       unawaited(_loadTask(taskId));
@@ -29,7 +29,7 @@ class EditorViewModel extends _$EditorViewModel {
     return const EditorUiState();
   }
 
-  Future<void> _loadTask(int taskId) async {
+  Future<void> _loadTask(String taskId) async {
     try {
       final task = await _repository.findTaskById(taskId);
       if (!ref.mounted) return;
@@ -109,7 +109,7 @@ class EditorViewModel extends _$EditorViewModel {
     );
   }
 
-  Future<EditorUiState> _updateTask(int id) async {
+  Future<EditorUiState> _updateTask(String id) async {
     final originalTask = await _repository.findTaskById(id);
     await _repository.updateTask(
       taskId: id,

--- a/lib/ui/editor/widgets/editor_screen.dart
+++ b/lib/ui/editor/widgets/editor_screen.dart
@@ -22,7 +22,7 @@ import 'package:go_router/go_router.dart';
 class EditorScreen extends ConsumerStatefulWidget {
   const EditorScreen({super.key, this.taskId});
 
-  final int? taskId;
+  final String? taskId;
 
   @override
   ConsumerState<EditorScreen> createState() => _EditorScreenState();

--- a/lib/ui/onboarding/widget/onboarding_pages.dart
+++ b/lib/ui/onboarding/widget/onboarding_pages.dart
@@ -187,7 +187,7 @@ class _OnboardingPage1Description extends StatelessWidget {
   static List<TaskItem> _demoTasks(DateTime now, BuildContext context) {
     return [
       TaskItem.scheduled(
-        id: 0,
+        id: 'dummy-1',
         name: context.l10n.onboardingDemoTask1,
         furigana: '',
         icon: '🐝',
@@ -196,14 +196,14 @@ class _OnboardingPage1Description extends StatelessWidget {
         scheduleUnit: ScheduleUnit.month,
         taskHistory: [
           TaskHistory(
-            id: 0,
+            id: 'dummy-1-1',
             executedAt: DateTime(now.year, now.month - 6, now.day),
             comment: null,
           ),
         ],
       ),
       TaskItem.scheduled(
-        id: 0,
+        id: 'dummy-2',
         name: context.l10n.onboardingDemoTask2,
         furigana: '',
         icon: '🚗',
@@ -212,14 +212,14 @@ class _OnboardingPage1Description extends StatelessWidget {
         scheduleUnit: ScheduleUnit.month,
         taskHistory: [
           TaskHistory(
-            id: 0,
+            id: 'dummy-2-1',
             executedAt: DateTime(now.year, now.month - 5, now.day - 1),
             comment: null,
           ),
         ],
       ),
       TaskItem.scheduled(
-        id: 0,
+        id: 'dummy-3',
         name: context.l10n.onboardingDemoTask3,
         furigana: '',
         icon: '🪥',
@@ -228,14 +228,14 @@ class _OnboardingPage1Description extends StatelessWidget {
         scheduleUnit: ScheduleUnit.month,
         taskHistory: [
           TaskHistory(
-            id: 0,
+            id: 'dummy-3-1',
             executedAt: DateTime(now.year, now.month, now.day - 3),
             comment: null,
           ),
         ],
       ),
       TaskItem.scheduled(
-        id: 0,
+        id: 'dummy-4',
         name: context.l10n.onboardingDemoTask4,
         furigana: '',
         icon: '🧪',
@@ -244,14 +244,14 @@ class _OnboardingPage1Description extends StatelessWidget {
         scheduleUnit: ScheduleUnit.week,
         taskHistory: [
           TaskHistory(
-            id: 0,
+            id: 'dummy-4-1',
             executedAt: DateTime(now.year, now.month, now.day - 7),
             comment: null,
           ),
         ],
       ),
       TaskItem.scheduled(
-        id: 0,
+        id: 'dummy-5',
         name: context.l10n.onboardingDemoTask5,
         furigana: '',
         icon: '👟',
@@ -260,7 +260,7 @@ class _OnboardingPage1Description extends StatelessWidget {
         scheduleUnit: ScheduleUnit.month,
         taskHistory: [
           TaskHistory(
-            id: 0,
+            id: 'dummy-5-1',
             executedAt: DateTime(now.year, now.month - 1, now.day),
             comment: null,
           ),
@@ -328,7 +328,7 @@ class _OnboardingPage2Description extends StatelessWidget {
             _titleArea(
               context,
               TaskItem.scheduled(
-                id: 0,
+                id: '0',
                 name: context.l10n.onboardingDemoTask6,
                 furigana: '',
                 icon: '✂️',

--- a/lib/ui/settings/viewmodel/dummy_tasks.dart
+++ b/lib/ui/settings/viewmodel/dummy_tasks.dart
@@ -25,32 +25,37 @@ List<TaskItem> buildDummyTasks({
     );
     if (dates.isEmpty) continue;
 
+    final taskIdStr = taskId.toString();
     final history = [
       for (final (index, date) in dates.indexed)
-        TaskHistory(id: index + 1, executedAt: date, comment: null),
+        TaskHistory(
+          id: '$taskIdStr-${index + 1}',
+          executedAt: date,
+          comment: null,
+        ),
     ];
 
     final item = switch (def.taskType) {
       TaskType.irregular => TaskItem.irregular(
-        id: taskId,
+        id: taskIdStr,
         name: def.name,
-        furigana: '',
+        furigana: def.furigana,
         icon: def.icon,
         color: def.color,
         taskHistory: history,
       ),
       TaskType.period => TaskItem.period(
-        id: taskId,
+        id: taskIdStr,
         name: def.name,
-        furigana: '',
+        furigana: def.furigana,
         icon: def.icon,
         color: def.color,
         taskHistory: history,
       ),
       TaskType.scheduled => TaskItem.scheduled(
-        id: taskId,
+        id: taskIdStr,
         name: def.name,
-        furigana: '',
+        furigana: def.furigana,
         icon: def.icon,
         color: def.color,
         scheduleValue: def.scheduleValue!,
@@ -88,6 +93,7 @@ List<DateTime> _generateDates({
 const _dummyTaskDefinition = [
   (
     name: '歯ブラシ交換',
+    furigana: 'はぶらしこうかん',
     icon: '🪥',
     color: TaskColor.none,
     taskType: TaskType.scheduled,
@@ -98,6 +104,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: 'エアコンフィルター清掃',
+    furigana: 'えあこんふぃるたーせいそう',
     icon: '🌬️',
     color: TaskColor.blue,
     taskType: TaskType.scheduled,
@@ -108,6 +115,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: 'エアコン本体クリーニング',
+    furigana: 'えあこんほんたいくりーにんぐ',
     icon: '❄️',
     color: TaskColor.blue,
     taskType: TaskType.scheduled,
@@ -118,6 +126,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: 'オイル交換',
+    furigana: 'おいるこうかん',
     icon: '🔧',
     color: TaskColor.none,
     taskType: TaskType.scheduled,
@@ -128,6 +137,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '洗車',
+    furigana: 'せんしゃ',
     icon: '🚗',
     color: TaskColor.none,
     taskType: TaskType.scheduled,
@@ -138,6 +148,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: 'タイヤローテーション',
+    furigana: 'たいやろーてーしょん',
     icon: '🔩',
     color: TaskColor.none,
     taskType: TaskType.scheduled,
@@ -148,6 +159,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: 'スニーカー洗濯',
+    furigana: 'すにーかーせんたく',
     icon: '👟',
     color: TaskColor.none,
     taskType: TaskType.scheduled,
@@ -158,6 +170,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: 'ベランダ掃除',
+    furigana: 'べらんだそうじ',
     icon: '🧹',
     color: TaskColor.orange,
     taskType: TaskType.scheduled,
@@ -168,6 +181,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: 'お風呂の防カビ剤交換',
+    furigana: 'おふろのぼうかびざいこうかん',
     icon: '🛁',
     color: TaskColor.none,
     taskType: TaskType.scheduled,
@@ -178,6 +192,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '植物への施肥',
+    furigana: 'しょくぶつへのせひ',
     icon: '🌱',
     color: TaskColor.green,
     taskType: TaskType.scheduled,
@@ -188,6 +203,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '冷蔵庫の霜取り',
+    furigana: 'れいぞうこのしもとり',
     icon: '🧊',
     color: TaskColor.none,
     taskType: TaskType.scheduled,
@@ -198,6 +214,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '排水口パイプ掃除',
+    furigana: 'はいすいこうぱいぷそうじ',
     icon: '💧',
     color: TaskColor.none,
     taskType: TaskType.scheduled,
@@ -208,6 +225,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '美容院',
+    furigana: 'びよういん',
     icon: '✂️',
     color: TaskColor.none,
     taskType: TaskType.period,
@@ -218,6 +236,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '窓ガラスの拭き掃除',
+    furigana: 'まどがらすのふきそうじ',
     icon: '🪟',
     color: TaskColor.none,
     taskType: TaskType.scheduled,
@@ -228,6 +247,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '健康診断',
+    furigana: 'けんこうしんだん',
     icon: '🏥',
     color: TaskColor.red,
     taskType: TaskType.scheduled,
@@ -238,6 +258,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '虫除けスプレー交換',
+    furigana: 'むしよけすぷれーこうかん',
     icon: '🦟',
     color: TaskColor.orange,
     taskType: TaskType.scheduled,
@@ -248,6 +269,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '猫の健康診断',
+    furigana: 'ねこのけんこうしんだん',
     icon: '🐱',
     color: TaskColor.none,
     taskType: TaskType.scheduled,
@@ -258,6 +280,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '布団干し',
+    furigana: 'ふとんほし',
     icon: '☀️',
     color: TaskColor.yellow,
     taskType: TaskType.period,
@@ -268,6 +291,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '冬服クリーニング',
+    furigana: 'ふゆふくくりーにんぐ',
     icon: '🧥',
     color: TaskColor.blue,
     taskType: TaskType.irregular,
@@ -278,6 +302,7 @@ const _dummyTaskDefinition = [
   ),
   (
     name: '財布の残高チェック',
+    furigana: 'さいふのざんだかちぇっく',
     icon: '👛',
     color: TaskColor.none,
     taskType: TaskType.irregular,

--- a/test/core/notification/task_notification_sync_test.dart
+++ b/test/core/notification/task_notification_sync_test.dart
@@ -25,7 +25,7 @@ void main() {
     group('通知が有効な場合', () {
       group('タスク追加', () {
         test('scheduledAt があるタスクは通知が登録される', () async {
-          final task = _makeScheduled(id: 1);
+          final task = _makeScheduled(id: '1');
           await sync.updateNotifications(
             setting: enabledSetting,
             previous: [],
@@ -37,7 +37,7 @@ void main() {
         });
 
         test('scheduledAt がないタスクは通知が削除される', () async {
-          final task = _makeIrregular(id: 1);
+          final task = _makeIrregular(id: '1');
           await sync.updateNotifications(
             setting: enabledSetting,
             previous: [],
@@ -49,10 +49,10 @@ void main() {
         });
 
         test('scheduledAt ありとなしが混在する場合に正しく分類される', () async {
-          final s1 = _makeScheduled(id: 1);
-          final s2 = _makeScheduled(id: 2);
-          final i1 = _makeIrregular(id: 3);
-          final i2 = _makeIrregular(id: 4);
+          final s1 = _makeScheduled(id: '1');
+          final s2 = _makeScheduled(id: '2');
+          final i1 = _makeIrregular(id: '3');
+          final i2 = _makeIrregular(id: '4');
           await sync.updateNotifications(
             setting: enabledSetting,
             previous: [],
@@ -66,7 +66,7 @@ void main() {
 
       group('タスク削除', () {
         test('削除されたタスクの通知が削除される', () async {
-          final task = _makeScheduled(id: 1);
+          final task = _makeScheduled(id: '1');
           await sync.updateNotifications(
             setting: enabledSetting,
             previous: [task],
@@ -78,8 +78,8 @@ void main() {
         });
 
         test('複数タスクのうち一部だけ削除された場合、削除分のみ解除される', () async {
-          final keep = _makeScheduled(id: 1);
-          final remove = _makeScheduled(id: 2);
+          final keep = _makeScheduled(id: '1');
+          final remove = _makeScheduled(id: '2');
           await sync.updateNotifications(
             setting: enabledSetting,
             previous: [keep, remove],
@@ -93,8 +93,8 @@ void main() {
 
       group('タスク更新', () {
         test('スケジュールが変わったタスクは旧通知が削除されて新通知が登録される', () async {
-          final old = _makeScheduled(id: 1, scheduleValue: 7);
-          final updated = _makeScheduled(id: 1, scheduleValue: 14);
+          final old = _makeScheduled(id: '1', scheduleValue: 7);
+          final updated = _makeScheduled(id: '1', scheduleValue: 14);
           await sync.updateNotifications(
             setting: enabledSetting,
             previous: [old],
@@ -106,9 +106,9 @@ void main() {
         });
 
         test('変更されたタスクと変更されていないタスクが混在する場合、変更分のみ処理される', () async {
-          final unchanged = _makeScheduled(id: 1);
-          final old = _makeScheduled(id: 2, scheduleValue: 7);
-          final updated = _makeScheduled(id: 2, scheduleValue: 14);
+          final unchanged = _makeScheduled(id: '1');
+          final old = _makeScheduled(id: '2', scheduleValue: 7);
+          final updated = _makeScheduled(id: '2', scheduleValue: 14);
           await sync.updateNotifications(
             setting: enabledSetting,
             previous: [unchanged, old],
@@ -122,7 +122,7 @@ void main() {
 
       group('変化なし', () {
         test('同じリストを渡した場合、通知メソッドは呼ばれない', () async {
-          final tasks = [_makeScheduled(id: 1), _makeScheduled(id: 2)];
+          final tasks = [_makeScheduled(id: '1'), _makeScheduled(id: '2')];
           await sync.updateNotifications(
             setting: enabledSetting,
             previous: tasks,
@@ -139,8 +139,14 @@ void main() {
       test('すべての通知が削除される', () async {
         await sync.updateNotifications(
           setting: disabledSetting,
-          previous: [_makeScheduled(id: 1), _makeIrregular(id: 2)],
-          current: [_makeScheduled(id: 3), _makeIrregular(id: 4)],
+          previous: [
+            _makeScheduled(id: '1'),
+            _makeIrregular(id: '2'),
+          ],
+          current: [
+            _makeScheduled(id: '3'),
+            _makeIrregular(id: '4'),
+          ],
         );
 
         expect(service.callRemovedAll, isTrue);
@@ -151,7 +157,7 @@ void main() {
 }
 
 TaskItem _makeScheduled({
-  required int id,
+  required String id,
   int scheduleValue = 7,
   int daysAgo = 7,
 }) => TaskItem.scheduled(
@@ -171,7 +177,7 @@ TaskItem _makeScheduled({
   ],
 );
 
-TaskItem _makeIrregular({required int id}) => TaskItem.irregular(
+TaskItem _makeIrregular({required String id}) => TaskItem.irregular(
   id: id,
   name: 'タスク$id',
   furigana: '',

--- a/test/data/model/task_item_test.dart
+++ b/test/data/model/task_item_test.dart
@@ -14,7 +14,7 @@ void main() {
     test('履歴が1件のとき null を返す', () {
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
         ],
       );
       expect(task.scheduledAt, isNull);
@@ -24,8 +24,8 @@ void main() {
       // 間隔: 31日 → 平均31日 → 2/1 + 31日 = 3/4
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
-          TaskHistory(id: 2, executedAt: DateTime(2025, 2, 1), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: '2', executedAt: DateTime(2025, 2, 1), comment: null),
         ],
       );
       expect(task.scheduledAt, DateTime(2025, 3, 4));
@@ -35,9 +35,17 @@ void main() {
       // 間隔: 10日, 20日 → 平均15日 → 1/31 + 15日 = 2/15
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
-          TaskHistory(id: 2, executedAt: DateTime(2025, 1, 11), comment: null),
-          TaskHistory(id: 3, executedAt: DateTime(2025, 1, 31), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(
+            id: '2',
+            executedAt: DateTime(2025, 1, 11),
+            comment: null,
+          ),
+          TaskHistory(
+            id: '3',
+            executedAt: DateTime(2025, 1, 31),
+            comment: null,
+          ),
         ],
       );
       expect(task.scheduledAt, DateTime(2025, 2, 15));
@@ -58,7 +66,7 @@ void main() {
         scheduleValue: 14,
         scheduleUnit: ScheduleUnit.day,
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
         ],
       );
       expect(task.scheduledAt, DateTime(2025, 1, 15));
@@ -69,7 +77,7 @@ void main() {
         scheduleValue: 2,
         scheduleUnit: ScheduleUnit.week,
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
         ],
       );
       expect(task.scheduledAt, DateTime(2025, 1, 15));
@@ -80,7 +88,11 @@ void main() {
         scheduleValue: 3,
         scheduleUnit: ScheduleUnit.month,
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 10), comment: null),
+          TaskHistory(
+            id: '1',
+            executedAt: DateTime(2025, 1, 10),
+            comment: null,
+          ),
         ],
       );
       expect(task.scheduledAt, DateTime(2025, 4, 10));
@@ -91,7 +103,7 @@ void main() {
     test('履歴が1件のとき空リストを返す', () {
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
         ],
       );
       expect(task.executionIntervalDays, isEmpty);
@@ -100,8 +112,8 @@ void main() {
     test('深夜0時の履歴: 1/1→2/1 は31日', () {
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
-          TaskHistory(id: 2, executedAt: DateTime(2025, 2, 1), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: '2', executedAt: DateTime(2025, 2, 1), comment: null),
         ],
       );
       expect(task.executionIntervalDays, [31]);
@@ -111,12 +123,12 @@ void main() {
       final task = _periodTask(
         taskHistory: [
           TaskHistory(
-            id: 1,
+            id: '1',
             executedAt: DateTime(2025, 1, 1, 22, 0),
             comment: null,
           ),
           TaskHistory(
-            id: 2,
+            id: '2',
             executedAt: DateTime(2025, 1, 2, 8, 0),
             comment: null,
           ),
@@ -131,17 +143,17 @@ void main() {
       final task = _periodTask(
         taskHistory: [
           TaskHistory(
-            id: 1,
+            id: '1',
             executedAt: DateTime(2025, 1, 1, 14, 0),
             comment: null,
           ),
           TaskHistory(
-            id: 2,
+            id: '2',
             executedAt: DateTime(2025, 2, 1, 8, 0),
             comment: null,
           ),
           TaskHistory(
-            id: 3,
+            id: '3',
             executedAt: DateTime(2025, 3, 4, 22, 0),
             comment: null,
           ),
@@ -163,7 +175,7 @@ void main() {
       // PeriodTask で履歴1件 → 間隔が計算できず期日未定
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
         ],
       );
       expect(task.computeProgress(DateTime(2025, 2, 1)), isA<NoDueDate>());
@@ -173,8 +185,8 @@ void main() {
       // lastExecutedAt=1/1, scheduledAt=3/4(+62日), now=2/1(+31日) → progress=0.5
       final task = _periodTask(
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
-          TaskHistory(id: 2, executedAt: DateTime(2025, 3, 4), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: '2', executedAt: DateTime(2025, 3, 4), comment: null),
         ],
       );
       // scheduledAt = 3/4 + 62日 = 5/5
@@ -190,7 +202,7 @@ void main() {
         scheduleValue: 30,
         scheduleUnit: ScheduleUnit.day,
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
         ],
       );
       // scheduledAt = 1/31, now = 2/15 → 超過
@@ -207,7 +219,7 @@ void main() {
         scheduleValue: 0,
         scheduleUnit: ScheduleUnit.day,
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
         ],
       );
       final progress = task.computeProgress(DateTime(2025, 1, 1));
@@ -223,7 +235,7 @@ void main() {
           scheduleUnit: ScheduleUnit.day,
           taskHistory: [
             TaskHistory(
-              id: 1,
+              id: '1',
               executedAt: DateTime(2026, 4, 23),
               comment: null,
             ),
@@ -240,7 +252,7 @@ void main() {
           scheduleUnit: ScheduleUnit.day,
           taskHistory: [
             TaskHistory(
-              id: 1,
+              id: '1',
               executedAt: DateTime(2026, 4, 24),
               comment: null,
             ),
@@ -261,7 +273,7 @@ void main() {
           scheduleUnit: ScheduleUnit.day,
           taskHistory: [
             TaskHistory(
-              id: 1,
+              id: '1',
               executedAt: DateTime(2025, 1, 1, 14, 0),
               comment: null,
             ),
@@ -279,7 +291,7 @@ void main() {
         scheduleValue: 30,
         scheduleUnit: ScheduleUnit.day,
         taskHistory: [
-          TaskHistory(id: 1, executedAt: DateTime(2025, 1, 1), comment: null),
+          TaskHistory(id: '1', executedAt: DateTime(2025, 1, 1), comment: null),
         ],
       );
 
@@ -322,7 +334,7 @@ void main() {
 
 TaskItem _periodTask({List<TaskHistory> taskHistory = const []}) =>
     TaskItem.period(
-      id: 1,
+      id: '1',
       name: 'テスト',
       furigana: 'てすと',
       icon: '📝',
@@ -335,7 +347,7 @@ TaskItem _scheduledTask({
   required ScheduleUnit scheduleUnit,
   List<TaskHistory> taskHistory = const [],
 }) => TaskItem.scheduled(
-  id: 1,
+  id: '1',
   name: 'テスト',
   furigana: 'てすと',
   icon: '📝',

--- a/test/data/repository/task/task_repository_test.dart
+++ b/test/data/repository/task/task_repository_test.dart
@@ -54,7 +54,7 @@ void main() {
     group('findTaskById', () {
       test('タスクを取得できない', () async {
         await expectLater(
-          () => repository.findTaskById(1),
+          () => repository.findTaskById('non-existent'),
           throwsA(isA<TaskLoadException>()),
         );
       });
@@ -63,7 +63,10 @@ void main() {
     group('recordExecution', () {
       test('実行を記録できない', () async {
         await expectLater(
-          () => repository.recordExecution(1, executedAt: DateTime.now()),
+          () => repository.recordExecution(
+            'non-existent',
+            executedAt: DateTime.now(),
+          ),
           throwsA(isA<TaskSaveException>()),
         );
       });
@@ -72,7 +75,10 @@ void main() {
     group('updateExecution', () {
       test('実行を更新できない', () async {
         await expectLater(
-          () => repository.updateExecution(1, executedAt: DateTime.now()),
+          () => repository.updateExecution(
+            'non-existent',
+            executedAt: DateTime.now(),
+          ),
           throwsA(isA<TaskUpdateException>()),
         );
       });
@@ -81,7 +87,7 @@ void main() {
     group('deleteExecution', () {
       test('実行を削除できない', () async {
         await expectLater(
-          () => repository.deleteExecution(1),
+          () => repository.deleteExecution('non-existent'),
           throwsA(isA<TaskDeleteException>()),
         );
       });
@@ -91,7 +97,7 @@ void main() {
       test('タスクを更新できない', () async {
         await expectLater(
           () => repository.updateTask(
-            taskId: 1,
+            taskId: 'non-existent',
             taskType: TaskType.period,
             name: 'x',
             icon: '📝',
@@ -105,7 +111,7 @@ void main() {
     group('deleteTask', () {
       test('タスクを削除できない', () async {
         await expectLater(
-          () => repository.deleteTask(1),
+          () => repository.deleteTask('non-existent'),
           throwsA(isA<TaskDeleteException>()),
         );
       });
@@ -114,7 +120,7 @@ void main() {
     group('restoreTask', () {
       test('タスクを復元できない', () async {
         const task = TaskItem.period(
-          id: 1,
+          id: 'test-id',
           name: 'x',
           furigana: '',
           icon: '📝',
@@ -136,6 +142,7 @@ void main() {
             .into(db.taskDefinitions)
             .insert(
               TaskDefinitionsCompanion.insert(
+                id: 'test-broken-id',
                 taskType: TaskType.scheduled,
                 name: 'config なしタスク',
                 furigana: '',
@@ -358,7 +365,7 @@ void main() {
 
     test('存在しないタスクは取得できない', () async {
       expect(
-        () => repository.findTaskById(999),
+        () => repository.findTaskById('non-existent'),
         throwsA(isA<TaskRepositoryException>()),
       );
     });
@@ -460,7 +467,7 @@ void main() {
   });
 
   group('updateExecution', () {
-    late int taskId;
+    late String taskId;
 
     setUp(() async {
       taskId = await repository.addTask(
@@ -682,7 +689,7 @@ void main() {
     });
 
     test('存在しない ID のとき null を emit する', () async {
-      final result = await repository.watchTaskById(999).first;
+      final result = await repository.watchTaskById('non-existent').first;
       expect(result, isNull);
     });
 

--- a/test/helpers/fake_task_repository.dart
+++ b/test/helpers/fake_task_repository.dart
@@ -30,7 +30,7 @@ class FakeTaskRepository implements TaskRepository {
   }
 
   @override
-  Stream<TaskItem?> watchTaskById(int taskId) {
+  Stream<TaskItem?> watchTaskById(String taskId) {
     unawaited(
       Future.microtask(() {
         if (!_controller.isClosed) _controller.add(List.of(_tasks));
@@ -42,7 +42,7 @@ class FakeTaskRepository implements TaskRepository {
   }
 
   @override
-  Future<TaskItem> findTaskById(int taskId) async {
+  Future<TaskItem> findTaskById(String taskId) async {
     if (shouldThrow) throw const TaskLoadException('テストエラー');
     final task = _tasks.where((t) => t.id == taskId).firstOrNull;
     if (task == null) throw TaskNotFoundException(taskId: taskId);
@@ -50,7 +50,7 @@ class FakeTaskRepository implements TaskRepository {
   }
 
   @override
-  Future<int> addTask({
+  Future<String> addTask({
     required TaskType taskType,
     required String name,
     required String icon,
@@ -61,7 +61,7 @@ class FakeTaskRepository implements TaskRepository {
     if (shouldThrow) throw const TaskSaveException('テストエラー');
     final id = _nextId++;
     final item = _buildTask(
-      id: id,
+      id: id.toString(),
       taskType: taskType,
       name: name,
       furigana: '',
@@ -73,12 +73,12 @@ class FakeTaskRepository implements TaskRepository {
     );
     _tasks.add(item);
     _notify();
-    return id;
+    return id.toString();
   }
 
   @override
   Future<void> updateTask({
-    required int taskId,
+    required String taskId,
     required TaskType taskType,
     required String name,
     required String icon,
@@ -108,18 +108,23 @@ class FakeTaskRepository implements TaskRepository {
 
   @override
   Future<TaskHistory> recordExecution(
-    int taskId, {
+    String taskId, {
     required DateTime executedAt,
     String? comment,
   }) async {
     if (shouldThrow) throw const TaskSaveException('テストエラー');
     lastRecordedComment = comment;
-    return TaskHistory(id: _nextId++, executedAt: executedAt, comment: comment);
+    final newTaskId = _nextId++;
+    return TaskHistory(
+      id: newTaskId.toString(),
+      executedAt: executedAt,
+      comment: comment,
+    );
   }
 
   @override
   Future<void> updateExecution(
-    int executionId, {
+    String executionId, {
     required DateTime executedAt,
     String? comment,
   }) async {
@@ -127,12 +132,12 @@ class FakeTaskRepository implements TaskRepository {
   }
 
   @override
-  Future<void> deleteExecution(int executionId) async {
+  Future<void> deleteExecution(String executionId) async {
     if (shouldThrow) throw const TaskDeleteException('テストエラー');
   }
 
   @override
-  Future<void> deleteTask(int taskId) async {
+  Future<void> deleteTask(String taskId) async {
     if (shouldThrow) throw const TaskDeleteException('テストエラー');
     _tasks.removeWhere((t) => t.id == taskId);
     _notify();
@@ -156,9 +161,9 @@ class FakeTaskRepository implements TaskRepository {
     if (!_controller.isClosed) _controller.addError(error);
   }
 
-  bool containsTask(int taskId) => _tasks.any((t) => t.id == taskId);
+  bool containsTask(String taskId) => _tasks.any((t) => t.id == taskId);
 
-  TaskItem? taskById(int taskId) =>
+  TaskItem? taskById(String taskId) =>
       _tasks.where((t) => t.id == taskId).firstOrNull;
 
   void dispose() => _controller.close();
@@ -168,7 +173,7 @@ class FakeTaskRepository implements TaskRepository {
   }
 
   static TaskItem _buildTask({
-    required int id,
+    required String id,
     required TaskType taskType,
     required String name,
     required String furigana,

--- a/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
+++ b/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
@@ -24,7 +24,7 @@ void main() {
     late AppDetailViewModel viewModel;
     late AppDetailUiState viewState;
 
-    void setUpContainer({int? taskId}) {
+    void setUpContainer({String? taskId}) {
       fakeRepository = FakeTaskRepository(initialTasks: _testTasks);
       container = ProviderContainer(
         overrides: [taskRepositoryProvider.overrideWith((_) => fakeRepository)],
@@ -34,7 +34,7 @@ void main() {
       );
     }
 
-    Future<void> setUpLoaded({int? taskId}) async {
+    Future<void> setUpLoaded({String? taskId}) async {
       final id = taskId ?? _taskOneHistory.id;
       setUpContainer(taskId: id);
       await waitUntil(container, provider, (s) => !s.isLoading);
@@ -528,7 +528,7 @@ void main() {
           ]) {
             test('$descriptionの履歴を削除後 undo で元のコメントが再作成される', () async {
               final history = TaskHistory(
-                id: 1,
+                id: 'h-test',
                 executedAt: DateTime(2026, 1, 1),
                 comment: comment,
               );
@@ -589,7 +589,7 @@ void main() {
 
 // Jan 1, Feb 1 (31 days), Mar 4 (31 days) → averageIntervalDays = 31
 const _taskNoHistory = TaskItem.period(
-  id: 1,
+  id: 'task-1',
   name: 'タスク（履歴なし）',
   furigana: 'たすく',
   icon: '📝',
@@ -598,26 +598,26 @@ const _taskNoHistory = TaskItem.period(
 );
 
 final _taskOneHistory = TaskItem.period(
-  id: 2,
+  id: 'task-2',
   name: 'タスク（履歴1件）',
   furigana: 'たすく',
   icon: '📝',
   color: TaskColor.blue,
   taskHistory: [
-    TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1), comment: null),
+    TaskHistory(id: 'h-1', executedAt: DateTime(2026, 1, 1), comment: null),
   ],
 );
 
 final _taskMultiHistory = TaskItem.period(
-  id: 3,
+  id: 'task-3',
   name: 'タスク（複数履歴）',
   furigana: 'たすく',
   icon: '📝',
   color: TaskColor.green,
   taskHistory: [
-    TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1), comment: null),
-    TaskHistory(id: 2, executedAt: DateTime(2026, 2, 1), comment: null),
-    TaskHistory(id: 3, executedAt: DateTime(2026, 3, 4), comment: null),
+    TaskHistory(id: 'h-1', executedAt: DateTime(2026, 1, 1), comment: null),
+    TaskHistory(id: 'h-2', executedAt: DateTime(2026, 2, 1), comment: null),
+    TaskHistory(id: 'h-3', executedAt: DateTime(2026, 3, 4), comment: null),
   ],
 );
 

--- a/test/ui/editor/viewmodel/editor_view_model_test.dart
+++ b/test/ui/editor/viewmodel/editor_view_model_test.dart
@@ -30,7 +30,7 @@ void main() {
       );
     }
 
-    Future<void> setUpLoaded({int? taskId}) async {
+    Future<void> setUpLoaded({String? taskId}) async {
       setUpContainer();
       final p = editorViewModelProvider(taskId: taskId);
       await waitUntil(container, p, (s) => !s.isLoading);
@@ -134,11 +134,11 @@ void main() {
         expect(viewState.snackBarMessage, isA<TaskCreateSuccess>());
 
         // undo 前はタスクが存在する
-        expect(fakeRepository.containsTask(100), true);
+        expect(fakeRepository.containsTask('100'), true);
 
         await viewState.snackBarMessage!.handler!();
 
-        expect(fakeRepository.containsTask(100), false);
+        expect(fakeRepository.containsTask('100'), false);
       });
 
       test('save() でリポジトリがエラーを返すと errorMessage が設定される', () async {
@@ -167,14 +167,16 @@ void main() {
         setUp(setUpContainer);
 
         test('データ取得中である', () {
-          final state = container.read(editorViewModelProvider(taskId: 1));
+          final state = container.read(
+            editorViewModelProvider(taskId: 'task-1'),
+          );
           expect(state.isLoading, true);
         });
       });
 
       group('ロード後', () {
         group('period タスク', () {
-          setUp(() async => setUpLoaded(taskId: 1));
+          setUp(() async => setUpLoaded(taskId: 'task-1'));
 
           test('タスクの内容が反映される', () {
             expect(viewState.isLoading, false);
@@ -187,7 +189,7 @@ void main() {
         });
 
         group('scheduled タスク', () {
-          setUp(() async => setUpLoaded(taskId: 2));
+          setUp(() async => setUpLoaded(taskId: 'task-2'));
 
           test('スケジュール設定が反映される', () {
             expect(viewState.isLoading, false);
@@ -198,7 +200,7 @@ void main() {
         });
 
         group('タスクが存在しない場合', () {
-          setUp(() async => setUpLoaded(taskId: 999));
+          setUp(() async => setUpLoaded(taskId: 'non-existent'));
 
           test('読み込みエラーが通知される', () {
             expect(viewState.isLoading, false);
@@ -215,7 +217,7 @@ void main() {
         });
 
         group('save', () {
-          setUp(() async => setUpLoaded(taskId: 1));
+          setUp(() async => setUpLoaded(taskId: 'task-1'));
 
           group('正常系', () {
             test('編集内容を保存できる', () async {
@@ -243,14 +245,14 @@ void main() {
               expect(viewState.snackBarMessage, isA<TaskUpdateSuccess>());
 
               // undo 前は更新後の値
-              expect(fakeRepository.taskById(1)?.name, '新しい名前');
-              expect(fakeRepository.taskById(1)?.color, TaskColor.green);
+              expect(fakeRepository.taskById('task-1')?.name, '新しい名前');
+              expect(fakeRepository.taskById('task-1')?.color, TaskColor.green);
 
               await viewState.snackBarMessage!.handler!();
 
               // undo 後は元の値に戻っている
-              expect(fakeRepository.taskById(1)?.name, '歯ブラシ交換');
-              expect(fakeRepository.taskById(1)?.color, TaskColor.blue);
+              expect(fakeRepository.taskById('task-1')?.name, '歯ブラシ交換');
+              expect(fakeRepository.taskById('task-1')?.color, TaskColor.blue);
             });
           });
         });
@@ -261,17 +263,17 @@ void main() {
 
 final _testTasks = [
   TaskItem.period(
-    id: 1,
+    id: 'task-1',
     name: '歯ブラシ交換',
     furigana: 'はぶらしこうかん',
     icon: '🪥',
     color: TaskColor.blue,
     taskHistory: [
-      TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1), comment: null),
+      TaskHistory(id: 'h-1', executedAt: DateTime(2026, 1, 1), comment: null),
     ],
   ),
   TaskItem.scheduled(
-    id: 2,
+    id: 'task-2',
     name: '虫避け交換',
     furigana: 'むしよけこうかん',
     icon: '🐝',
@@ -279,7 +281,7 @@ final _testTasks = [
     scheduleValue: 2,
     scheduleUnit: ScheduleUnit.week,
     taskHistory: [
-      TaskHistory(id: 2, executedAt: DateTime(2026, 1, 1), comment: null),
+      TaskHistory(id: 'h-2', executedAt: DateTime(2026, 1, 1), comment: null),
     ],
   ),
 ];

--- a/test/ui/home/viewmodel/home_view_model_test.dart
+++ b/test/ui/home/viewmodel/home_view_model_test.dart
@@ -38,7 +38,7 @@ void main() {
   final now = DateTime.now();
   final classificationTasks = [
     TaskItem.scheduled(
-      id: 10,
+      id: 'task-10',
       name: '超過',
       furigana: '',
       icon: '📝',
@@ -47,14 +47,14 @@ void main() {
       scheduleUnit: ScheduleUnit.day,
       taskHistory: [
         TaskHistory(
-          id: 10,
+          id: 'h-10',
           executedAt: now.subtract(const Duration(days: 10)),
           comment: null,
         ),
       ],
     ),
     TaskItem.scheduled(
-      id: 11,
+      id: 'task-11',
       name: '今日',
       furigana: '',
       icon: '📝',
@@ -63,14 +63,14 @@ void main() {
       scheduleUnit: ScheduleUnit.day,
       taskHistory: [
         TaskHistory(
-          id: 11,
+          id: 'h-11',
           executedAt: now.subtract(const Duration(days: 7)),
           comment: null,
         ),
       ],
     ),
     TaskItem.scheduled(
-      id: 12,
+      id: 'task-12',
       name: '今週',
       furigana: '',
       icon: '📝',
@@ -79,24 +79,24 @@ void main() {
       scheduleUnit: ScheduleUnit.day,
       taskHistory: [
         TaskHistory(
-          id: 12,
+          id: 'h-12',
           executedAt: now.subtract(const Duration(days: 4)),
           comment: null,
         ),
       ],
     ),
     TaskItem.scheduled(
-      id: 13,
+      id: 'task-13',
       name: '将来',
       furigana: '',
       icon: '📝',
       color: TaskColor.none,
       scheduleValue: 14,
       scheduleUnit: ScheduleUnit.day,
-      taskHistory: [TaskHistory(id: 13, executedAt: now, comment: null)],
+      taskHistory: [TaskHistory(id: 'h-13', executedAt: now, comment: null)],
     ),
     const TaskItem.period(
-      id: 14,
+      id: 'task-14',
       name: '不定期',
       furigana: '',
       icon: '📝',
@@ -443,7 +443,7 @@ void main() {
 
 final _colorTasks = [
   const TaskItem.period(
-    id: 30,
+    id: 'task-30',
     name: 'レッドA',
     furigana: 'れっどえー',
     icon: '📝',
@@ -451,7 +451,7 @@ final _colorTasks = [
     taskHistory: [],
   ),
   const TaskItem.period(
-    id: 31,
+    id: 'task-31',
     name: 'レッドB',
     furigana: 'れっどびー',
     icon: '📝',
@@ -459,7 +459,7 @@ final _colorTasks = [
     taskHistory: [],
   ),
   const TaskItem.period(
-    id: 32,
+    id: 'task-32',
     name: 'ブルー',
     furigana: 'ぶるー',
     icon: '📝',
@@ -467,7 +467,7 @@ final _colorTasks = [
     taskHistory: [],
   ),
   const TaskItem.period(
-    id: 33,
+    id: 'task-33',
     name: 'グレー',
     furigana: 'ぐれー',
     icon: '📝',
@@ -478,23 +478,23 @@ final _colorTasks = [
 
 final _testTasks = [
   TaskItem.period(
-    id: 1,
+    id: 'task-1',
     name: '歯ブラシ交換',
     furigana: 'はぶらしこうかん',
     icon: '📝',
     color: TaskColor.blue,
     taskHistory: [
-      TaskHistory(id: 1, executedAt: DateTime(2026, 1, 1), comment: null),
+      TaskHistory(id: 'h-1', executedAt: DateTime(2026, 1, 1), comment: null),
     ],
   ),
   TaskItem.period(
-    id: 2,
+    id: 'task-2',
     name: '散髪',
     furigana: 'さんぱつ',
     icon: '📝',
     color: TaskColor.none,
     taskHistory: [
-      TaskHistory(id: 2, executedAt: DateTime(2026, 1, 1), comment: null),
+      TaskHistory(id: 'h-2', executedAt: DateTime(2026, 1, 1), comment: null),
     ],
   ),
 ];


### PR DESCRIPTION
## 概要

Firebase Firestore への移行準備として、DB・モデル全体のIDを `int`（auto-increment）から `String`（UUID v4）に変更した。

Firestore はドキュメントIDとして文字列を使用するため、端末間でデータを同期する将来の実装に備えた変更。

## 変更内容

- Drift テーブルの主キーを `integer().autoIncrement()` → `text()` に変更（`uuid` パッケージで v4 生成）
- `TaskItem` / `TaskHistory` / `TaskRepositoryException` の id フィールドを `int` → `String` に変更
- `NotificationServiceImpl`: `flutter_local_notifications` が要求する `int` 型の通知IDを `taskId.hashCode & 0x7FFFFFFF` でビットマスクして渡す private 関数 `_notificationId` を追加
- テスト中は `_CrashlyticsOutput` を使わないよう `AppLogger` を修正
- ダミータスクにふりがなを追加
- テストコードをすべて `String` ID に対応