### PR TITLE
Firebase移行 phase3: 認証・リポジトリ切り替え・AsyncNotifier移行

### DIFF
--- a/lib/core/auth/app_user.dart
+++ b/lib/core/auth/app_user.dart
@@ -1,0 +1,21 @@
+import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
+
+sealed class AppUser {
+  const AppUser();
+}
+
+/// SQLiteでローカル動作するためのユーザー
+class LocalUser extends AppUser {
+  const LocalUser();
+}
+
+/// Firebase CloudStore
+class FirebaseAppUser extends AppUser {
+  const FirebaseAppUser(this._user);
+
+  final firebase_auth.User _user;
+
+  String get id => _user.uid;
+
+  bool get isAnonymous => _user.isAnonymous;
+}

--- a/lib/core/notification/task_notification_sync_notifier.dart
+++ b/lib/core/notification/task_notification_sync_notifier.dart
@@ -21,7 +21,7 @@ class TaskNotificationSyncNotifier extends _$TaskNotificationSyncNotifier {
     await ref.watch(canScheduleExactAlarmsProvider.future);
     final service = await ref.read(notificationServiceProvider.future);
     final syncLogic = TaskNotificationSync(service);
-    final repository = ref.read(taskRepositoryProvider);
+    final repository = await ref.read(taskRepositoryProvider.future);
 
     final sub = repository
         .allTaskItems()

--- a/lib/core/util/async_value_extension.dart
+++ b/lib/core/util/async_value_extension.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+extension AsyncValueX<T> on AsyncValue<T> {
+  AsyncValue<T> update(T Function(T) updater) =>
+      AsyncData(updater(requireValue));
+}

--- a/lib/data/repository/task/firestore_task_repository.dart
+++ b/lib/data/repository/task/firestore_task_repository.dart
@@ -1,0 +1,68 @@
+import 'package:dawnbreaker/data/model/schedule_unit.dart';
+import 'package:dawnbreaker/data/model/task_color.dart';
+import 'package:dawnbreaker/data/model/task_history.dart';
+import 'package:dawnbreaker/data/model/task_item.dart';
+import 'package:dawnbreaker/data/model/task_type.dart';
+import 'package:dawnbreaker/data/repository/task/task_repository.dart';
+
+class FirestoreTaskRepository implements TaskRepository {
+  FirestoreTaskRepository({required this.userId});
+
+  final String userId;
+
+  @override
+  Stream<List<TaskItem>> allTaskItems() => throw UnimplementedError();
+
+  @override
+  Stream<TaskItem?> watchTaskById(String taskId) => throw UnimplementedError();
+
+  @override
+  Future<TaskItem> findTaskById(String taskId) => throw UnimplementedError();
+
+  @override
+  Future<String> addTask({
+    required TaskType taskType,
+    required String name,
+    required String icon,
+    required TaskColor color,
+    int? scheduleValue,
+    ScheduleUnit? scheduleUnit,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> updateTask({
+    required String taskId,
+    required TaskType taskType,
+    required String name,
+    required String icon,
+    required TaskColor color,
+    int? scheduleValue,
+    ScheduleUnit? scheduleUnit,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<TaskHistory> recordExecution(
+    String taskId, {
+    required DateTime executedAt,
+    String? comment,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> updateExecution(
+    String executionId, {
+    required DateTime executedAt,
+    String? comment,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> deleteExecution(String executionId) => throw UnimplementedError();
+
+  @override
+  Future<void> deleteTask(String taskId) => throw UnimplementedError();
+
+  @override
+  Future<void> deleteAllTasks() => throw UnimplementedError();
+
+  @override
+  Future<void> restoreTask(TaskItem taskItem) => throw UnimplementedError();
+}

--- a/lib/data/repository/task/task_repository_impl.dart
+++ b/lib/data/repository/task/task_repository_impl.dart
@@ -7,8 +7,11 @@ import 'package:dawnbreaker/data/model/task_color.dart';
 import 'package:dawnbreaker/data/model/task_history.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/data/model/task_type.dart';
+import 'package:dawnbreaker/core/auth/app_user.dart';
+import 'package:dawnbreaker/data/repository/task/firestore_task_repository.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository_exception.dart';
+import 'package:dawnbreaker/data/repository/user/current_user_provider.dart';
 import 'package:drift/drift.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:uuid/uuid.dart';
@@ -18,11 +21,15 @@ part 'task_repository_impl.g.dart';
 const _uuid = Uuid();
 
 @riverpod
-TaskRepository taskRepository(Ref ref) {
-  return TaskRepositoryImpl(
-    db: ref.watch(appDatabaseProvider),
-    furiganaTranslate: ref.watch(furiganaTranslateProvider),
-  );
+Future<TaskRepository> taskRepository(Ref ref) async {
+  final user = await ref.watch(currentUserProvider.future);
+  return switch (user) {
+    LocalUser() => TaskRepositoryImpl(
+      db: ref.watch(appDatabaseProvider),
+      furiganaTranslate: ref.watch(furiganaTranslateProvider),
+    ),
+    FirebaseAppUser(:final id) => FirestoreTaskRepository(userId: id),
+  };
 }
 
 class TaskRepositoryImpl implements TaskRepository {

--- a/lib/data/repository/user/current_user_provider.dart
+++ b/lib/data/repository/user/current_user_provider.dart
@@ -1,0 +1,9 @@
+import 'package:dawnbreaker/core/auth/app_user.dart';
+import 'package:dawnbreaker/data/repository/user/firebase_user_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'current_user_provider.g.dart';
+
+@riverpod
+Future<AppUser> currentUser(Ref ref) =>
+    ref.watch(userRepositoryProvider).getUser();

--- a/lib/data/repository/user/firebase_user_repository.dart
+++ b/lib/data/repository/user/firebase_user_repository.dart
@@ -1,0 +1,19 @@
+import 'package:dawnbreaker/core/auth/app_user.dart';
+import 'package:dawnbreaker/data/repository/user/user_repository.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'firebase_user_repository.g.dart';
+
+@riverpod
+UserRepository userRepository(Ref ref) => FirebaseUserRepository();
+
+class FirebaseUserRepository implements UserRepository {
+  @override
+  Future<AppUser> getUser() async {
+    final auth = FirebaseAuth.instance;
+    if (auth.currentUser != null) return FirebaseAppUser(auth.currentUser!);
+    final credential = await auth.signInAnonymously();
+    return FirebaseAppUser(credential.user!);
+  }
+}

--- a/lib/data/repository/user/local_user_repository.dart
+++ b/lib/data/repository/user/local_user_repository.dart
@@ -1,0 +1,9 @@
+import 'package:dawnbreaker/core/auth/app_user.dart';
+import 'package:dawnbreaker/data/repository/user/user_repository.dart';
+
+class LocalUserRepository implements UserRepository {
+  const LocalUserRepository();
+
+  @override
+  Future<AppUser> getUser() async => const LocalUser();
+}

--- a/lib/data/repository/user/user_repository.dart
+++ b/lib/data/repository/user/user_repository.dart
@@ -1,0 +1,5 @@
+import 'package:dawnbreaker/core/auth/app_user.dart';
+
+abstract interface class UserRepository {
+  Future<AppUser> getUser();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:dawnbreaker/core/notification/notification_permission_observer.d
 import 'package:dawnbreaker/core/notification/notification_service_impl.dart';
 import 'package:dawnbreaker/core/notification/task_notification_sync_notifier.dart';
 import 'package:dawnbreaker/data/preferences/shared_preferences_provider.dart';
+import 'package:dawnbreaker/data/repository/user/firebase_user_repository.dart';
 import 'package:dawnbreaker/firebase_options_dev.dart' as dev_options;
 import 'package:dawnbreaker/firebase_options_prod.dart' as prod_options;
 import 'package:firebase_core/firebase_core.dart';
@@ -45,6 +46,7 @@ void main() async {
   final container = ProviderContainer(
     overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
   );
+  await container.read(userRepositoryProvider).getUser();
   final notificationService = await container.read(
     notificationServiceProvider.future,
   );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,8 @@ import 'package:dawnbreaker/core/notification/notification_permission_observer.d
 import 'package:dawnbreaker/core/notification/notification_service_impl.dart';
 import 'package:dawnbreaker/core/notification/task_notification_sync_notifier.dart';
 import 'package:dawnbreaker/data/preferences/shared_preferences_provider.dart';
-import 'package:dawnbreaker/data/repository/user/firebase_user_repository.dart';
+import 'package:dawnbreaker/data/repository/task/task_repository_impl.dart';
+import 'package:dawnbreaker/data/repository/user/current_user_provider.dart';
 import 'package:dawnbreaker/firebase_options_dev.dart' as dev_options;
 import 'package:dawnbreaker/firebase_options_prod.dart' as prod_options;
 import 'package:firebase_core/firebase_core.dart';
@@ -46,7 +47,8 @@ void main() async {
   final container = ProviderContainer(
     overrides: [sharedPreferencesProvider.overrideWithValue(preferences)],
   );
-  await container.read(userRepositoryProvider).getUser();
+  await container.read(currentUserProvider.future);
+  await container.read(taskRepositoryProvider.future);
   final notificationService = await container.read(
     notificationServiceProvider.future,
   );

--- a/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
+++ b/lib/ui/app_detail/viewmodel/app_detail_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:dawnbreaker/core/logger/app_logger.dart';
+import 'package:dawnbreaker/core/util/async_value_extension.dart';
 import 'package:dawnbreaker/data/model/task_history.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
 import 'package:dawnbreaker/data/repository/task/task_repository.dart';
@@ -17,8 +18,8 @@ class AppDetailViewModel extends _$AppDetailViewModel {
   late TaskRepository _repository;
 
   @override
-  AppDetailUiState build({required String taskId}) {
-    _repository = ref.read(taskRepositoryProvider);
+  Future<AppDetailUiState> build({required String taskId}) async {
+    _repository = await ref.read(taskRepositoryProvider.future);
     _loadTask(taskId);
     return const AppDetailUiState();
   }
@@ -30,22 +31,26 @@ class AppDetailViewModel extends _$AppDetailViewModel {
           (task) {
             // 削除されたときは前の画面に戻る
             if (!ref.mounted || task == null) {
-              state = state.copyWith(
-                isLoading: false,
-                task: null,
-                historyStats: null,
-                daysSinceLastExecution: null,
-                averageIntervalDays: null,
-                shouldPop: true,
+              state = state.update(
+                (s) => s.copyWith(
+                  isLoading: false,
+                  task: null,
+                  historyStats: null,
+                  daysSinceLastExecution: null,
+                  averageIntervalDays: null,
+                  shouldPop: true,
+                ),
               );
             } else {
-              state = state.updateTaskItem(task);
+              state = state.update((s) => s.updateTaskItem(task));
             }
           },
           onError: (Object e, StackTrace s) {
             logger.e('watchTaskById stream error', error: e, stackTrace: s);
             if (!ref.mounted) return;
-            state = state.copyWith(isLoading: false, shouldPop: true);
+            state = state.update(
+              (s) => s.copyWith(isLoading: false, shouldPop: true),
+            );
           },
         );
     ref.onDispose(subscription.cancel);
@@ -63,24 +68,28 @@ class AppDetailViewModel extends _$AppDetailViewModel {
         comment: comment,
       );
       if (!ref.mounted) return;
-      state = state.copyWith(
-        snackBarMessage: TaskExecutionUpdateSuccess(
-          handler: () => updateExecution(
-            history,
-            executedAt: history.executedAt,
-            comment: history.comment,
+      state = state.update(
+        (s) => s.copyWith(
+          snackBarMessage: TaskExecutionUpdateSuccess(
+            handler: () => updateExecution(
+              history,
+              executedAt: history.executedAt,
+              comment: history.comment,
+            ),
           ),
         ),
       );
     } on TaskRepositoryException catch (e, s) {
       logger.e('updateExecution failed', error: e, stackTrace: s);
       if (!ref.mounted) return;
-      state = state.copyWith(
-        dialogMessage: TaskUpdateErrorMessage(
-          primaryHandler: () => updateExecution(
-            history,
-            executedAt: executedAt,
-            comment: comment,
+      state = state.update(
+        (s) => s.copyWith(
+          dialogMessage: TaskUpdateErrorMessage(
+            primaryHandler: () => updateExecution(
+              history,
+              executedAt: executedAt,
+              comment: comment,
+            ),
           ),
         ),
       );
@@ -88,37 +97,41 @@ class AppDetailViewModel extends _$AppDetailViewModel {
   }
 
   void showDeleteTaskDialog() {
-    final task = state.task;
+    final task = state.requireValue.task;
     if (task == null) return;
-
-    state = state.copyWith(
-      dialogMessage: DeleteTaskConfirmMessage(
-        task.name,
-        primaryHandler: () => deleteTask(),
+    state = state.update(
+      (s) => s.copyWith(
+        dialogMessage: DeleteTaskConfirmMessage(
+          task.name,
+          primaryHandler: () => deleteTask(),
+        ),
       ),
     );
   }
 
   @visibleForTesting
   Future<void> deleteTask() async {
-    final task = state.task;
+    final task = state.requireValue.task;
     if (task == null) return;
-
     try {
       await _repository.deleteTask(task.id);
       if (!ref.mounted) return;
       // タスク削除で watchTaskById で前の画面に戻る処理が走る
-      state = state.copyWith(
-        snackBarMessage: TaskDeleteSuccess(
-          taskName: task.name,
-          handler: () => _repository.restoreTask(task),
+      state = state.update(
+        (s) => s.copyWith(
+          snackBarMessage: TaskDeleteSuccess(
+            taskName: task.name,
+            handler: () => _repository.restoreTask(task),
+          ),
         ),
       );
     } on TaskRepositoryException catch (e, s) {
       logger.e('deleteTask failed', error: e, stackTrace: s);
       if (!ref.mounted) return;
-      state = state.copyWith(
-        dialogMessage: TaskDeleteErrorMessage(primaryHandler: deleteTask),
+      state = state.update(
+        (s) => s.copyWith(
+          dialogMessage: TaskDeleteErrorMessage(primaryHandler: deleteTask),
+        ),
       );
     }
   }
@@ -135,18 +148,22 @@ class AppDetailViewModel extends _$AppDetailViewModel {
         comment: comment,
       );
       if (!ref.mounted) return;
-      state = state.copyWith(
-        snackBarMessage: TaskCompleteSuccess(
-          taskName: task.name,
-          handler: () => _repository.deleteExecution(history.id),
+      state = state.update(
+        (s) => s.copyWith(
+          snackBarMessage: TaskCompleteSuccess(
+            taskName: task.name,
+            handler: () => _repository.deleteExecution(history.id),
+          ),
         ),
       );
     } on TaskRepositoryException catch (e, s) {
       logger.e('recordExecution failed', error: e, stackTrace: s);
       if (!ref.mounted) return;
-      state = state.copyWith(
-        dialogMessage: TaskSaveErrorMessage(
-          primaryHandler: () => recordExecution(task, executedAt, comment),
+      state = state.update(
+        (s) => s.copyWith(
+          dialogMessage: TaskSaveErrorMessage(
+            primaryHandler: () => recordExecution(task, executedAt, comment),
+          ),
         ),
       );
     }
@@ -156,23 +173,27 @@ class AppDetailViewModel extends _$AppDetailViewModel {
     try {
       await _repository.deleteExecution(history.id);
       if (!ref.mounted) return;
-      state = state.copyWith(
-        snackBarMessage: TaskExecutionDeleteSuccess(
-          taskName: task.name,
-          executedAt: history.executedAt,
-          handler: () => _repository.recordExecution(
-            task.id,
+      state = state.update(
+        (s) => s.copyWith(
+          snackBarMessage: TaskExecutionDeleteSuccess(
+            taskName: task.name,
             executedAt: history.executedAt,
-            comment: history.comment,
+            handler: () => _repository.recordExecution(
+              task.id,
+              executedAt: history.executedAt,
+              comment: history.comment,
+            ),
           ),
         ),
       );
     } on TaskRepositoryException catch (e, s) {
       logger.e('deleteExecution failed', error: e, stackTrace: s);
       if (!ref.mounted) return;
-      state = state.copyWith(
-        dialogMessage: TaskExecutionDeleteErrorMessage(
-          primaryHandler: () => deleteExecution(task, history),
+      state = state.update(
+        (s) => s.copyWith(
+          dialogMessage: TaskExecutionDeleteErrorMessage(
+            primaryHandler: () => deleteExecution(task, history),
+          ),
         ),
       );
     }

--- a/lib/ui/app_detail/widgets/app_detail_screen.dart
+++ b/lib/ui/app_detail/widgets/app_detail_screen.dart
@@ -37,14 +37,21 @@ class _AppDetailScreenState extends ConsumerState<AppDetailScreen>
   @override
   Widget build(BuildContext context) {
     final provider = appDetailViewModelProvider(taskId: widget.taskId);
-    listenMessages(provider);
+    listenAsyncMessages(provider);
 
-    ref.listen(provider.select((s) => s.shouldPop), (_, shouldPop) {
-      if (shouldPop) context.pop();
+    ref.listen(provider, (_, next) {
+      if (next case AsyncData(:final value) when value.shouldPop) {
+        context.pop();
+      }
     });
 
-    final uiState = ref.watch(provider);
+    final uiState = ref.watch(provider).value;
     final viewModel = ref.read(provider.notifier);
+
+    if (uiState == null) {
+      return Scaffold(backgroundColor: context.appColorScheme.bg);
+    }
+
     final task = uiState.task;
     final historyStats = uiState.historyStats;
 

--- a/lib/ui/common/messages_mixin.dart
+++ b/lib/ui/common/messages_mixin.dart
@@ -19,4 +19,24 @@ mixin MessagesListenMixin<T extends ConsumerStatefulWidget>
       AppSnackBar.show(context, next);
     });
   }
+
+  void listenAsyncMessages<S extends BaseUiState>(
+    ProviderListenable<AsyncValue<S>> provider,
+  ) {
+    ref.listen(provider.select((async) => async.value?.dialogMessage), (
+      prev,
+      next,
+    ) {
+      if (next == null || prev?.id == next.id) return;
+      unawaited(AppDialog.show(context, next));
+    });
+
+    ref.listen(provider.select((async) => async.value?.snackBarMessage), (
+      prev,
+      next,
+    ) {
+      if (next == null || prev?.id == next.id) return;
+      AppSnackBar.show(context, next);
+    });
+  }
 }

--- a/lib/ui/editor/viewmodel/editor_view_model.dart
+++ b/lib/ui/editor/viewmodel/editor_view_model.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dawnbreaker/core/logger/app_logger.dart';
+import 'package:dawnbreaker/core/util/async_value_extension.dart';
 import 'package:dawnbreaker/data/model/schedule_unit.dart';
 import 'package:dawnbreaker/data/model/task_color.dart';
 import 'package:dawnbreaker/data/model/task_item.dart';
@@ -20,8 +21,8 @@ class EditorViewModel extends _$EditorViewModel {
   late TaskRepository _repository;
 
   @override
-  EditorUiState build({String? taskId}) {
-    _repository = ref.read(taskRepositoryProvider);
+  Future<EditorUiState> build({String? taskId}) async {
+    _repository = await ref.read(taskRepositoryProvider.future);
     if (taskId != null) {
       unawaited(_loadTask(taskId));
       return const EditorUiState(isLoading: true);
@@ -33,44 +34,54 @@ class EditorViewModel extends _$EditorViewModel {
     try {
       final task = await _repository.findTaskById(taskId);
       if (!ref.mounted) return;
-      state = EditorUiState(
-        icon: task.icon,
-        name: task.name,
-        color: task.color,
-        taskHistory: task.taskHistory,
-        type: task.taskType,
-        scheduleValue: task.scheduleValueOrDefault,
-        scheduleUnit: task.scheduleUnitOrDefault,
+      state = AsyncData(
+        EditorUiState(
+          icon: task.icon,
+          name: task.name,
+          color: task.color,
+          taskHistory: task.taskHistory,
+          type: task.taskType,
+          scheduleValue: task.scheduleValueOrDefault,
+          scheduleUnit: task.scheduleUnitOrDefault,
+        ),
       );
     } on TaskRepositoryException catch (e, s) {
       logger.e('_loadTask failed', error: e, stackTrace: s);
       if (!ref.mounted) return;
-      state = state.copyWith(
-        isLoading: false,
-        dialogMessage: TaskLoadErrorMessage(
-          primaryHandler: () => _loadTask(taskId),
+      state = state.update(
+        (s) => s.copyWith(
+          isLoading: false,
+          dialogMessage: TaskLoadErrorMessage(
+            primaryHandler: () => _loadTask(taskId),
+          ),
         ),
       );
     }
   }
 
-  void updateIcon(String icon) => state = state.copyWith(icon: icon);
+  void updateIcon(String icon) =>
+      state = state.update((s) => s.copyWith(icon: icon));
 
-  void updateName(String name) => state = state.copyWith(name: name);
+  void updateName(String name) =>
+      state = state.update((s) => s.copyWith(name: name));
 
-  void updateType(TaskType type) => state = state.copyWith(type: type);
+  void updateType(TaskType type) =>
+      state = state.update((s) => s.copyWith(type: type));
 
-  void updateColor(TaskColor color) => state = state.copyWith(color: color);
+  void updateColor(TaskColor color) =>
+      state = state.update((s) => s.copyWith(color: color));
 
   void updateScheduleValue(int value) =>
-      state = state.copyWith(scheduleValue: value);
+      state = state.update((s) => s.copyWith(scheduleValue: value));
 
   void updateScheduleUnit(ScheduleUnit unit) =>
-      state = state.copyWith(scheduleUnit: unit);
+      state = state.update((s) => s.copyWith(scheduleUnit: unit));
 
   Future<void> save() async {
-    if (!state.canSave) return;
-    state = state.copyWith(isSaving: true, dialogMessage: null);
+    if (!state.requireValue.canSave) return;
+    state = state.update(
+      (s) => s.copyWith(isSaving: true, dialogMessage: null),
+    );
     try {
       final EditorUiState newState;
       if (taskId == null) {
@@ -79,52 +90,56 @@ class EditorViewModel extends _$EditorViewModel {
         newState = await _updateTask(taskId!);
       }
       if (!ref.mounted) return;
-      state = newState;
+      state = AsyncData(newState);
     } on TaskRepositoryException catch (e, s) {
       logger.e('save failed', error: e, stackTrace: s);
       if (!ref.mounted) return;
-      state = state.copyWith(
-        isSaving: false,
-        dialogMessage: TaskSaveErrorMessage(primaryHandler: save),
+      state = state.update(
+        (s) => s.copyWith(
+          isSaving: false,
+          dialogMessage: TaskSaveErrorMessage(primaryHandler: save),
+        ),
       );
     }
   }
 
   Future<EditorUiState> _createTask() async {
+    final s = state.requireValue;
     final newId = await _repository.addTask(
-      taskType: state.type,
-      name: state.name,
-      icon: state.icon,
-      color: state.color,
-      scheduleValue: state.scheduleValue,
-      scheduleUnit: state.scheduleUnit,
+      taskType: s.type,
+      name: s.name,
+      icon: s.icon,
+      color: s.color,
+      scheduleValue: s.scheduleValue,
+      scheduleUnit: s.scheduleUnit,
     );
-    return state.copyWith(
+    return state.requireValue.copyWith(
       isSaving: false,
       isSaved: true,
       snackBarMessage: TaskCreateSuccess(
-        taskName: state.name,
+        taskName: s.name,
         handler: () => _repository.deleteTask(newId),
       ),
     );
   }
 
   Future<EditorUiState> _updateTask(String id) async {
+    final s = state.requireValue;
     final originalTask = await _repository.findTaskById(id);
     await _repository.updateTask(
       taskId: id,
-      taskType: state.type,
-      name: state.name,
-      icon: state.icon,
-      color: state.color,
-      scheduleValue: state.scheduleValue,
-      scheduleUnit: state.scheduleUnit,
+      taskType: s.type,
+      name: s.name,
+      icon: s.icon,
+      color: s.color,
+      scheduleValue: s.scheduleValue,
+      scheduleUnit: s.scheduleUnit,
     );
-    return state.copyWith(
+    return state.requireValue.copyWith(
       isSaving: false,
       isSaved: true,
       snackBarMessage: TaskUpdateSuccess(
-        taskName: state.name,
+        taskName: s.name,
         handler: () => _revertTask(originalTask),
       ),
     );

--- a/lib/ui/editor/widgets/editor_screen.dart
+++ b/lib/ui/editor/widgets/editor_screen.dart
@@ -36,8 +36,10 @@ class _EditorScreenState extends ConsumerState<EditorScreen>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final state = ref.read(editorViewModelProvider(taskId: widget.taskId));
-      _nameController.text = state.name;
+      final state = ref
+          .read(editorViewModelProvider(taskId: widget.taskId))
+          .value;
+      _nameController.text = state?.name ?? '';
     });
   }
 
@@ -50,13 +52,15 @@ class _EditorScreenState extends ConsumerState<EditorScreen>
   @override
   Widget build(BuildContext context) {
     final provider = editorViewModelProvider(taskId: widget.taskId);
-    listenMessages(provider);
+    listenAsyncMessages(provider);
 
-    ref.listen(provider.select((s) => s.isSaved), (_, isSaved) {
-      if (isSaved == true) context.pop();
+    ref.listen(provider, (_, next) {
+      if (next case AsyncData(:final value) when value.isSaved) {
+        context.pop();
+      }
     });
 
-    final uiState = ref.watch(provider);
+    final uiState = ref.watch(provider).value;
     final viewModel = ref.read(provider.notifier);
     final isNew = widget.taskId == null;
 
@@ -67,7 +71,7 @@ class _EditorScreenState extends ConsumerState<EditorScreen>
             : context.l10n.editorTitleEdit,
         onBack: () => context.pop(),
       ),
-      body: uiState.isLoading
+      body: uiState == null || uiState.isLoading
           ? const SizedBox.shrink()
           : _EditorBody(
               uiState: uiState,
@@ -75,7 +79,11 @@ class _EditorScreenState extends ConsumerState<EditorScreen>
               nameController: _nameController,
             ),
       bottomNavigationBar: _SaveBar(
-        enabled: uiState.canSave && !uiState.isLoading && !uiState.isSaving,
+        enabled:
+            uiState != null &&
+            uiState.canSave &&
+            !uiState.isLoading &&
+            !uiState.isSaving,
         isNew: isNew,
         onSave: viewModel.save,
       ),

--- a/lib/ui/home/viewmodel/home_view_model.dart
+++ b/lib/ui/home/viewmodel/home_view_model.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dawnbreaker/core/logger/app_logger.dart';
+import 'package:dawnbreaker/core/util/async_value_extension.dart';
 import 'package:dawnbreaker/core/util/stream_util.dart' show combineLatest4;
 import 'package:dawnbreaker/data/model/color_setting.dart';
 import 'package:dawnbreaker/data/model/home_display_mode.dart';
@@ -23,8 +24,8 @@ class HomeViewModel extends _$HomeViewModel {
   late SettingsRepository _settingsRepository;
 
   @override
-  HomeUiState build() {
-    _taskRepository = ref.read(taskRepositoryProvider);
+  Future<HomeUiState> build() async {
+    _taskRepository = await ref.read(taskRepositoryProvider.future);
     _settingsRepository = ref.read(settingsRepositoryProvider);
     _initialize();
     return const HomeUiState(isLoading: true);
@@ -41,12 +42,14 @@ class HomeViewModel extends _$HomeViewModel {
         HomeDisplayMode mode,
         List<ColorSetting> colorSettings,
         bool progressBarAnimationEnabled,
-      ) => state = state.copyWith(
-        isLoading: false,
-        tasks: tasks,
-        displayMode: mode,
-        colorSettings: colorSettings,
-        progressBarAnimationEnabled: progressBarAnimationEnabled,
+      ) => state = state.update(
+        (s) => s.copyWith(
+          isLoading: false,
+          tasks: tasks,
+          displayMode: mode,
+          colorSettings: colorSettings,
+          progressBarAnimationEnabled: progressBarAnimationEnabled,
+        ),
       ),
     );
     ref.onDispose(() => unawaited(disposable()));
@@ -57,13 +60,13 @@ class HomeViewModel extends _$HomeViewModel {
   }
 
   void updateSearchQuery(String query) {
-    if (query == state.searchQuery) return;
-    state = state.copyWith(searchQuery: query);
+    if (query == state.requireValue.searchQuery) return;
+    state = state.update((s) => s.copyWith(searchQuery: query));
   }
 
   void updateFilter(HomeFilter filter) {
-    if (filter == state.selectedFilter) return;
-    state = state.copyWith(selectedFilter: filter);
+    if (filter == state.requireValue.selectedFilter) return;
+    state = state.update((s) => s.copyWith(selectedFilter: filter));
   }
 
   Future<void> recordExecution(
@@ -78,18 +81,22 @@ class HomeViewModel extends _$HomeViewModel {
         comment: comment,
       );
       if (!ref.mounted) return;
-      state = state.copyWith(
-        snackBarMessage: TaskCompleteSuccess(
-          taskName: task.name,
-          handler: () => _taskRepository.deleteExecution(history.id),
+      state = state.update(
+        (s) => s.copyWith(
+          snackBarMessage: TaskCompleteSuccess(
+            taskName: task.name,
+            handler: () => _taskRepository.deleteExecution(history.id),
+          ),
         ),
       );
     } on TaskRepositoryException catch (e, s) {
       logger.e('recordExecution failed', error: e, stackTrace: s);
       if (!ref.mounted) return;
-      state = state.copyWith(
-        dialogMessage: TaskSaveErrorMessage(
-          primaryHandler: () => recordExecution(task, executedAt, comment),
+      state = state.update(
+        (s) => s.copyWith(
+          dialogMessage: TaskSaveErrorMessage(
+            primaryHandler: () => recordExecution(task, executedAt, comment),
+          ),
         ),
       );
     }

--- a/lib/ui/home/widgets/home_screen.dart
+++ b/lib/ui/home/widgets/home_screen.dart
@@ -38,17 +38,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
   @override
   Widget build(BuildContext context) {
-    listenMessages(homeViewModelProvider);
-    ref.listen(homeViewModelProvider.select((s) => s.isLoading), (
-      _,
-      isLoading,
-    ) {
-      if (!isLoading) FlutterNativeSplash.remove();
+    listenAsyncMessages(homeViewModelProvider);
+    ref.listen(homeViewModelProvider, (_, next) {
+      if (next case AsyncData(:final value) when !value.isLoading) {
+        FlutterNativeSplash.remove();
+      }
     });
-    final uiState = ref.watch(homeViewModelProvider);
+    final uiState = ref.watch(homeViewModelProvider).value;
     final viewModel = ref.read(homeViewModelProvider.notifier);
 
-    if (uiState.isLoading) {
+    if (uiState == null || uiState.isLoading) {
       return const Scaffold();
     }
 

--- a/lib/ui/settings/viewmodel/settings_view_model.dart
+++ b/lib/ui/settings/viewmodel/settings_view_model.dart
@@ -143,7 +143,7 @@ class SettingsViewModel extends _$SettingsViewModel {
   }
 
   Future<void> generateDummyTasks() async {
-    final repository = ref.read(taskRepositoryProvider);
+    final repository = await ref.read(taskRepositoryProvider.future);
     await repository.deleteAllTasks();
     for (final task in buildDummyTasks(now: DateTime.now(), random: Random())) {
       await repository.restoreTask(task);
@@ -153,7 +153,7 @@ class SettingsViewModel extends _$SettingsViewModel {
   }
 
   Future<void> deleteAllTasks() async {
-    final repository = ref.read(taskRepositoryProvider);
+    final repository = await ref.read(taskRepositoryProvider.future);
     await repository.deleteAllTasks();
     if (!ref.mounted) return;
     state = state.copyWith(snackBarMessage: AllTasksDeletedMessage());

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -185,6 +185,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  cloud_firestore:
+    dependency: "direct main"
+    description:
+      name: cloud_firestore
+      sha256: f0dba6cedc1e1c84bb811c32ce1343cde4f1aa796dc4b5d00344e16a5342aed0
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
+  cloud_firestore_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_firestore_platform_interface
+      sha256: "07a03c220bc4579418a9e2ef02914a4c86b2b0c21d68a832faa523096bc20a00"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.3"
+  cloud_firestore_web:
+    dependency: transitive
+    description:
+      name: cloud_firestore_web
+      sha256: a75fec71ecf6327f9a657a4c6b4dad5099d77bf578d110e10b233237f6cad3c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.6.0"
   code_assets:
     dependency: transitive
     description:
@@ -361,6 +385,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.1+9"
+  firebase_auth:
+    dependency: "direct main"
+    description:
+      name: firebase_auth
+      sha256: "7996a49c4b4054573eac9124c1c412095ae1406ca367bd2373de1ad2eaba04b8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.4"
+  firebase_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_auth_platform_interface
+      sha256: "2975965782c8cc46fe5bafc653882617e6fbdceed4499c97345c980734c50d2e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.3"
+  firebase_auth_web:
+    dependency: transitive
+    description:
+      name: firebase_auth_web
+      sha256: b35db5997b32889885dc9b1420b7c81b704f1ec153c3bb2efd228733e1878119
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.3"
   firebase_core:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   flutter_native_splash: ^2.4.5
   firebase_core: ^4.0.0
   firebase_crashlytics: ^5.0.0
+  firebase_auth: ^6.0.0
+  cloud_firestore: ^6.0.0
   logger: ^2.5.0
   firebase_analytics: ^12.0.0
 

--- a/test/helpers/riverpod_test_helper.dart
+++ b/test/helpers/riverpod_test_helper.dart
@@ -14,3 +14,20 @@ Future<void> waitUntil<T>(
   await completer.future;
   sub.close();
 }
+
+Future<void> waitUntilAsync<T>(
+  ProviderContainer container,
+  ProviderListenable<AsyncValue<T>> provider,
+  bool Function(T) condition,
+) async {
+  final completer = Completer<void>();
+  final sub = container.listen(provider, (_, next) {
+    if (next.hasValue &&
+        condition(next.requireValue) &&
+        !completer.isCompleted) {
+      completer.complete();
+    }
+  }, fireImmediately: true);
+  await completer.future;
+  sub.close();
+}

--- a/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
+++ b/test/ui/app_detail/viewmodel/app_detail_view_model_test.dart
@@ -37,25 +37,21 @@ void main() {
     Future<void> setUpLoaded({String? taskId}) async {
       final id = taskId ?? _taskOneHistory.id;
       setUpContainer(taskId: id);
-      await waitUntil(container, provider, (s) => !s.isLoading);
+      await waitUntilAsync(container, provider, (s) => !s.isLoading);
       viewModel = container.read(provider.notifier);
-      container.listen(
-        provider,
-        (_, next) => viewState = next,
-        fireImmediately: true,
-      );
+      container.listen(provider, (_, next) {
+        if (next.hasValue) viewState = next.requireValue;
+      }, fireImmediately: true);
     }
 
     Future<void> setUpLoadedWithThrow() async {
       setUpContainer();
       fakeRepository.shouldThrow = true;
-      await waitUntil(container, provider, (s) => !s.isLoading);
+      await waitUntilAsync(container, provider, (s) => !s.isLoading);
       viewModel = container.read(provider.notifier);
-      container.listen(
-        provider,
-        (_, next) => viewState = next,
-        fireImmediately: true,
-      );
+      container.listen(provider, (_, next) {
+        if (next.hasValue) viewState = next.requireValue;
+      }, fireImmediately: true);
     }
 
     tearDown(() {
@@ -69,9 +65,9 @@ void main() {
       test('データ取得前はローディング中でタスクは表示されない', () {
         final state = container.read(provider);
         expect(state.isLoading, true);
-        expect(state.task, isNull);
-        expect(state.historyStats, isNull);
-        expect(state.shouldPop, false);
+        expect(state.value?.task, isNull);
+        expect(state.value?.historyStats, isNull);
+        expect(state.value?.shouldPop ?? false, false);
       });
     });
 

--- a/test/ui/editor/viewmodel/editor_view_model_test.dart
+++ b/test/ui/editor/viewmodel/editor_view_model_test.dart
@@ -33,9 +33,11 @@ void main() {
     Future<void> setUpLoaded({String? taskId}) async {
       setUpContainer();
       final p = editorViewModelProvider(taskId: taskId);
-      await waitUntil(container, p, (s) => !s.isLoading);
+      await waitUntilAsync(container, p, (s) => !s.isLoading);
       viewModel = container.read(p.notifier);
-      container.listen(p, (_, next) => viewState = next, fireImmediately: true);
+      container.listen(p, (_, next) {
+        if (next.hasValue) viewState = next.requireValue;
+      }, fireImmediately: true);
     }
 
     tearDown(() {
@@ -44,15 +46,14 @@ void main() {
     });
 
     group('新規作成モード', () {
-      setUp(() {
+      setUp(() async {
         setUpContainer();
         final p = editorViewModelProvider();
         viewModel = container.read(p.notifier);
-        container.listen(
-          p,
-          (_, next) => viewState = next,
-          fireImmediately: true,
-        );
+        viewState = await container.read(p.future);
+        container.listen(p, (_, next) {
+          if (next.hasValue) viewState = next.requireValue;
+        }, fireImmediately: false);
       });
 
       test('初期状態が正しい', () {
@@ -148,12 +149,15 @@ void main() {
         );
         final p = editorViewModelProvider();
         EditorUiState? localState;
-        c.listen(p, (_, next) => localState = next, fireImmediately: true);
         addTearDown(() {
           c.dispose();
           throwingRepo.dispose();
         });
         final n = c.read(p.notifier);
+        localState = await c.read(p.future);
+        c.listen(p, (_, next) {
+          if (next.hasValue) localState = next.requireValue;
+        }, fireImmediately: false);
         n.updateName('散髪');
         await n.save();
         expect(localState!.isSaved, false);

--- a/test/ui/home/viewmodel/home_view_model_test.dart
+++ b/test/ui/home/viewmodel/home_view_model_test.dart
@@ -131,13 +131,15 @@ void main() {
       FakeSettingsRepository? settings,
     }) async {
       setUpContainer(tasks: tasks, settings: settings);
-      await waitUntil(container, homeViewModelProvider, (s) => !s.isLoading);
-      viewModel = container.read(homeViewModelProvider.notifier);
-      container.listen(
+      await waitUntilAsync(
+        container,
         homeViewModelProvider,
-        (_, next) => viewState = next,
-        fireImmediately: true,
+        (s) => !s.isLoading,
       );
+      viewModel = container.read(homeViewModelProvider.notifier);
+      container.listen(homeViewModelProvider, (_, next) {
+        if (next.hasValue) viewState = next.requireValue;
+      }, fireImmediately: true);
     }
 
     tearDown(() {
@@ -151,12 +153,15 @@ void main() {
       test('ローディング中でタスクが表示されない', () {
         final state = container.read(homeViewModelProvider);
         expect(state.isLoading, true);
-        expect(state.tasks, isEmpty);
-        expect(state.searchQuery, '');
+        expect(state.value?.tasks ?? [], isEmpty);
+        expect(state.value?.searchQuery ?? '', '');
       });
 
       test('タスクがない', () {
-        expect(container.read(homeViewModelProvider).hasTasks, false);
+        expect(
+          container.read(homeViewModelProvider).value?.hasTasks ?? false,
+          false,
+        );
       });
     });
 


### PR DESCRIPTION
## 変更内容

- **匿名認証の追加**: `FirebaseUserRepository` で Firebase 匿名サインイン、`LocalUserRepository` で SQLite ユーザーを抽象化
- **`AppUser` sealed class**: `LocalUser` / `FirebaseAppUser` でユーザー種別を型安全に表現
- **`taskRepositoryProvider` の非同期化**: ユーザー種別に応じて SQLite / Firestore リポジトリを切り替え
- **`FirestoreTaskRepository` stub**: インターフェース実装済み（全メソッドは `UnimplementedError`）
- **ViewModel を `AsyncNotifier` に移行**: `HomeViewModel` / `EditorViewModel` / `AppDetailViewModel`
- **`AsyncValue.update()` extension 追加**: `state = state.update((s) => s.copyWith(...))` で状態更新を簡潔に記述
- **`ref.listen` を if-case パターンマッチに統一**: `select + == true` パターンを廃止
- **`listenAsyncMessages` 追加**: `MessagesListenMixin` を `AsyncValue` プロバイダーに対応